### PR TITLE
Human readable actor names

### DIFF
--- a/lib/flipper/ui/actions/feature.rb
+++ b/lib/flipper/ui/actions/feature.rb
@@ -14,6 +14,7 @@ module Flipper
           @feature = Decorators::Feature.new(flipper_feature)
           descriptions = Flipper::UI.configuration.descriptions_source.call([flipper_feature.key])
           @feature.description = descriptions[@feature.key]
+          @feature.actor_names = Flipper::UI.configuration.actor_names_source.call(@feature.actors_value)
           @page_title = "#{@feature.key} // Features"
           @percentages = [0, 1, 5, 10, 25, 50, 100]
 

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -45,6 +45,11 @@ module Flipper
       # page, and optionally the `features` pages. Defaults to empty block.
       attr_accessor :descriptions_source
 
+      # Public: If you set this, Flipper::UI will fetch actor names
+      # from your external source. Descriptions for `actors` will be shown on `feature`
+      # page. Defaults to empty block.
+      attr_accessor :actor_names_source
+
       # Public: Should feature descriptions be show on the `features` list page.
       # Default false. Only works when using descriptions.
       attr_accessor :show_feature_description_in_list
@@ -70,6 +75,7 @@ module Flipper
       ).freeze
 
       DEFAULT_DESCRIPTIONS_SOURCE = ->(_keys) { {} }
+      DEFAULT_ACTOR_NAMES_SOURCE = ->(_keys) { {} }
 
       def initialize
         @delete = Option.new("Danger Zone", "Deleting a feature removes it from the list of features and disables it for everyone.")
@@ -81,6 +87,7 @@ module Flipper
         @cloud_recommendation = true
         @add_actor_placeholder = "a flipper id"
         @descriptions_source = DEFAULT_DESCRIPTIONS_SOURCE
+        @actor_names_source = DEFAULT_ACTOR_NAMES_SOURCE
         @show_feature_description_in_list = false
         @actors_separator = ','
         @confirm_fully_enable = false

--- a/lib/flipper/ui/decorators/feature.rb
+++ b/lib/flipper/ui/decorators/feature.rb
@@ -15,6 +15,10 @@ module Flipper
         # configured for Flipper::UI.
         attr_accessor :description
 
+        # Internal: Used to preload actor names if actor_names_source is
+        # configured for Flipper::UI.
+        attr_accessor :actor_names
+
         # Public: Returns name titleized.
         def pretty_name
           @pretty_name ||= Util.titleize(name)

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -64,7 +64,13 @@
           <div class="card-body bg-lightest border-bottom py-3">
             <div class="row align-items-center">
               <div class="col col-mr-auto pl-md-5">
-                <h6 class="m-0"><%= item %></h6>
+                <h6 class="m-0">
+                  <% if Flipper::UI::Util.present?(@feature.actor_names[item]) %>
+                    <%= "#{@feature.actor_names[item]} (#{item})" %>
+                  <% else %>
+                    <%= item %>
+                  <% end %>
+                </h6>
               </div>
               <div class="col col-auto">
                 <% unless Flipper::UI.configuration.read_only %>

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -112,6 +112,29 @@ RSpec.describe Flipper::UI::Actions::Feature do
       expect(last_response.body).to include('Enabled for 0% of actors')
       expect(last_response.body).to include('Most in-depth search')
     end
+
+    context 'custom actor names' do
+      before do
+        actor = Flipper::Actor.new('some_actor_name')
+        flipper['search'].enable_actor(actor)
+
+        Flipper::UI.configure do |config|
+          config.actor_names_source = lambda { |_keys|
+            {
+              "some_actor_name" => "Some Actor Name",
+              "some_other_actor_name" => "Some Other Actor Name",
+            }
+          }
+        end
+        
+        get '/features/search'
+      end
+
+      it 'renders template with custom actor names' do
+        expect(last_response.body).to include('Some Actor Name (some_actor_name)')
+        expect(last_response.body).not_to include('Some Other Actor Name')
+      end
+    end
   end
 
   describe 'GET /features/:feature with _features in feature name' do

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -110,6 +110,12 @@ RSpec.describe Flipper::UI::Configuration do
     end
   end
 
+  describe "#actor_names_source" do
+    it "has default value" do
+      expect(configuration.actor_names_source.call(%w[foo bar])).to eq({})
+    end
+  end
+
   describe "#confirm_fully_enable" do
     it "has default value" do
       expect(configuration.confirm_fully_enable).to eq(false)

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -114,6 +114,20 @@ RSpec.describe Flipper::UI::Configuration do
     it "has default value" do
       expect(configuration.actor_names_source.call(%w[foo bar])).to eq({})
     end
+
+    context "actor names source is provided" do
+      it "can be updated" do
+        configuration.actor_names_source = lambda do |_keys|
+          YAML.load_file(FlipperRoot.join('spec/support/actor_names.yml'))
+        end
+        keys = %w[actor_1 foo]
+        result = configuration.actor_names_source.call(keys)
+        expected = {
+          "actor_name_1" => "Actor #1",
+        }
+        expect(result).to eq(expected)
+      end
+    end
   end
 
   describe "#confirm_fully_enable" do

--- a/spec/support/actor_names.yml
+++ b/spec/support/actor_names.yml
@@ -1,0 +1,1 @@
+actor_name_1: 'Actor #1'


### PR DESCRIPTION
This makes actor names more readable. Made sure there were no N+1 queries like @jnunemaker suggested!

I also wrote a deserializer to convert actor identifiers to ActiveRecord fields:
```ruby
def self.humanize_identifiers(keys, field)
  grouped_keys = {}
  actor_names = {}

  keys.each do |key|
    parts = key.split(";")
    grouped_keys[parts.first] ||= []
    grouped_keys[parts.first] << parts.second
  end

  grouped_keys.each do |model, ids|
    model.constantize.where(id: ids).find_each do |resource|
      actor_names["#{resource.class.name};#{resource.id}"] = resource.send(field)
    end
  end

  actor_names
end
```

I'm not sure how that can fit in the project, apart from adding it to the README. Suggestions appreciated.
