### PR TITLE
Add #enabled? to ActiveRecord models

### DIFF
--- a/lib/flipper/model/active_record.rb
+++ b/lib/flipper/model/active_record.rb
@@ -7,6 +7,25 @@ module Flipper
       def flipper_properties
         {"type" => self.class.name}.merge(attributes)
       end
+
+      # Check if a feature is enabled for this record or any associated actors
+      # returned by `#flipper_actors`
+      def enabled?(feature_name)
+        Flipper.enabled?(feature_name, *flipper_actors)
+      end
+
+      # Returns the set of actors associated with this record. Override to
+      # return any other records that should be considered actors.
+      #
+      #   class User < ApplicationRecord
+      #     # …
+      #     def flipper_actors
+      #       [self, company]
+      #     end
+      #   end
+      def flipper_actors
+        [self]
+      end
     end
   end
 end

--- a/spec/flipper/model/active_record_spec.rb
+++ b/spec/flipper/model/active_record_spec.rb
@@ -45,4 +45,34 @@ RSpec.describe Flipper::Model::ActiveRecord do
       })
     end
   end
+
+  describe "enabled?" do
+    subject { User.create!(name: "Test") }
+
+    module Friendable
+      attr_accessor :friends
+
+      def flipper_actors
+        [self] + Array(friends)
+      end
+    end
+
+    it "returns false if feature is disabled" do
+      expect(subject.enabled?(:stats)).to be(false)
+    end
+
+    it "returns true if feature is enabled for actor" do
+      Flipper.enable :stats, subject
+      expect(subject.enabled?(:stats)).to be(true)
+    end
+
+    it "returns true if feature is enabled for associated actor" do
+      friend = User.create!(name: "Friend")
+      subject.extend Friendable
+      subject.friends = [friend]
+
+      Flipper.enable :stats, friend
+      expect(subject.enabled?(:stats)).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
Adds `#enabled?` to all ActiveRecord models as shorthand for `Flipper.enabled?(:feature_name, model)`…with a bonus…

One thing that has always felt awkward is that I'm never quite sure who/what to use as an actor when building a new feature. Is it user-centric? Or some other other model like `Organization` or `Project`? In #710 we added the ability to check multiple actors at once, which is great, but it's still awkward to always have to have `Flipper.enabled?(:feature, current_user, *current_user&.organizations)` sprinkled throughout the code.

With this change, you can define `#flipper_actors` on any model, and calling `#enabled?` will check the feature against the relevant actors.

```ruby
class User < ApplicationRecord
  has_many :memberships
  has_many :organizations, through: :memberships

  def flipper_actors
    [self] + organizations
  end
end
```

So now `current_user.enabled?(:new_feature)` will check if it's enabled for a specific user or any organization that they are part of.
