### PR TITLE
Use base_class to determine flipper_id for ActiveRecord actors

### DIFF
--- a/lib/flipper/model/active_record.rb
+++ b/lib/flipper/model/active_record.rb
@@ -1,7 +1,18 @@
 module Flipper
   module Model
     module ActiveRecord
-      include Flipper::Identifier
+      # The id of the record when used as an actor.
+      #
+      #   class User < ActiveRecord::Base
+      #   end
+      #
+      #   user = User.first
+      #   Flipper.enable :some_feature, user
+      #   Flipper.enabled? :some_feature, user #=> true
+      #
+      def flipper_id
+        "#{self.class.base_class.name};#{id}"
+      end
 
       # Properties used to evaluate expressions
       def flipper_properties

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -94,12 +94,6 @@ RSpec.describe Flipper::Engine do
         if: nil
       })
     end
-
-    it "defines #flipper_id on AR::Base" do
-      subject
-      require 'active_record'
-      expect(ActiveRecord::Base.ancestors).to include(Flipper::Identifier)
-    end
   end
 
   context 'with cloud' do
@@ -181,7 +175,7 @@ RSpec.describe Flipper::Engine do
     end
   end
 
-  it "defines #flipper_properties on AR::Base" do
+  it "includes model methods" do
     subject
     require 'active_record'
     expect(ActiveRecord::Base.ancestors).to include(Flipper::Model::ActiveRecord)

--- a/spec/flipper/model/active_record_spec.rb
+++ b/spec/flipper/model/active_record_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe Flipper::Model::ActiveRecord do
     include Flipper::Model::ActiveRecord
   end
 
+  class Admin < User
+  end
+
+  describe "flipper_id" do
+    it "returns class name and id" do
+      expect(User.new(id: 1).flipper_id).to eq("User;1")
+    end
+
+    it "uses base class name" do
+      expect(Admin.new(id: 2).flipper_id).to eq("User;2")
+    end
+  end
+
   describe "flipper_properties" do
     subject { User.create!(name: "Test", age: 22, is_confirmed: true) }
 


### PR DESCRIPTION
Given this model:

```ruby
class MyEngine::User < User
end
```

Flipper currently considers these two different actors:

```ruby
User.first.flipper_id # => "User;1"
MyEngine::User.first.flipper_id # => "MyEngine::User;1"
```

This PR uses ActiveRecord's `base_class` method, which returns the first non-abstract class in the class hierarchy, as the class to use in the `#flipper_id` method.

```ruby
MyEngine::User.first.flipper_id # => "User;1"
```

Fixes #757 