### PR TITLE
Allow head requests to api

### DIFF
--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -12,6 +12,7 @@ module Flipper
       app = ->(_) { [404, { 'content-type'.freeze => CONTENT_TYPE }, ['{}'.freeze]] }
       builder = Rack::Builder.new
       yield builder if block_given?
+      builder.use Rack::Head
       builder.use Flipper::Api::JsonParams
       builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
       builder.use Flipper::Api::Middleware, env_key: env_key

--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -19,6 +19,7 @@ module Flipper
       extend Forwardable
 
       VALID_REQUEST_METHOD_NAMES = Set.new([
+                                             'head'.freeze,
                                              'get'.freeze,
                                              'post'.freeze,
                                              'put'.freeze,
@@ -147,8 +148,12 @@ module Flipper
       private
 
       # Private: Returns the request method converted to an action method.
+      # Converts head to get.
       def request_method_name
-        @request_method_name ||= @request.request_method.downcase
+        @request_method_name ||= begin
+          name = @request.request_method.downcase
+          name == "head" ? "get" : name
+        end
       end
 
       # Private: split request path by "/"

--- a/spec/flipper/api/action_spec.rb
+++ b/spec/flipper/api/action_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Flipper::Api::Action do
         [200, {}, 'get']
       end
 
+      def head
+        [200, {}, 'head']
+      end
+
       def post
         [200, {}, 'post']
       end
@@ -34,6 +38,12 @@ RSpec.describe Flipper::Api::Action do
 
     it 'will run get' do
       fake_request = Struct.new(:request_method, :env, :session).new('GET', {}, {})
+      action = action_subclass.new(flipper, fake_request)
+      expect(action.run).to eq([200, {}, 'get'])
+    end
+
+    it 'will run head' do
+      fake_request = Struct.new(:request_method, :env, :session).new('HEAD', {}, {})
       action = action_subclass.new(flipper, fake_request)
       expect(action.run).to eq([200, {}, 'get'])
     end

--- a/spec/flipper/api_spec.rb
+++ b/spec/flipper/api_spec.rb
@@ -14,6 +14,20 @@ RSpec.describe Flipper::Api do
     end
   end
 
+  describe "Head requests" do
+    let(:app) { build_api(flipper) }
+
+    it "are allowed but perform get and return no body" do
+      flipper.enable :a
+      flipper.disable :b
+
+      head '/features'
+
+      expect(last_response.status).to be(200)
+      expect(last_response.body).to be_empty
+    end
+  end
+
   describe 'Initializing middleware lazily with a block' do
     let(:app) { build_api(-> { flipper }) }
 


### PR DESCRIPTION
@bkeepers @garrettdimon any downside to doing it this way? I mostly just want to make `curl -Is` work with api requests.