### PR TITLE
Use Rails global constant

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -200,4 +200,4 @@ require 'flipper/types/percentage_of_time'
 require 'flipper/typecast'
 require 'flipper/version'
 
-require "flipper/engine" if defined?(Rails)
+require "flipper/engine" if defined?(::Rails)

--- a/lib/flipper/cloud/routes.rb
+++ b/lib/flipper/cloud/routes.rb
@@ -2,7 +2,7 @@
 Rails.application.routes.draw do
   if ENV["FLIPPER_CLOUD_TOKEN"] && ENV["FLIPPER_CLOUD_SYNC_SECRET"]
     require 'flipper/cloud'
-    config = Rails.application.config.flipper
+    config = ::Rails.application.config.flipper
 
     cloud_app = Flipper::Cloud.app(nil,
       env_key: config.env_key,

--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -1,5 +1,5 @@
 module Flipper
-  class Engine < Rails::Engine
+  class Engine < ::Rails::Engine
     paths["config/routes.rb"] = ["lib/flipper/cloud/routes.rb"]
 
     config.before_configuration do

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -75,7 +75,7 @@ module Flipper
 
       # Rails 7.1 changed the signature of this function.
       # Checking if > 7.0.99 rather than >= 7.1 so that 7.1 pre-release versions are included.
-      COLOR_OPTIONS = if Rails.gem_version > Gem::Version.new('7.0.99')
+      COLOR_OPTIONS = if ::Rails.gem_version > Gem::Version.new('7.0.99')
         { bold: true }.freeze
       else
         true

--- a/lib/generators/flipper/active_record_generator.rb
+++ b/lib/generators/flipper/active_record_generator.rb
@@ -13,11 +13,11 @@ module Flipper
       end
 
       def self.migration_version
-        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]" if requires_migration_number?
+        "[#{::Rails::VERSION::MAJOR}.#{::Rails::VERSION::MINOR}]" if requires_migration_number?
       end
 
       def self.requires_migration_number?
-        Rails::VERSION::MAJOR.to_i >= 5
+        ::Rails::VERSION::MAJOR.to_i >= 5
       end
 
       def create_migration_file


### PR DESCRIPTION
When I updated my application to `Ruby 3.2.2` I start getting the following error

```
 undefined method `gem_version' for Flipper::Rails:Module (NoMethodError)
```

From this line

```ruby
COLOR_OPTIONS = if Rails.gem_version > Gem::Version.new('7.0.99')
```

The reason is that `Rails` in this context is mistaken for `Flipper::Rails` instead of the global `Rails`. 