### PR TITLE
Define default Adapter#name

### DIFF
--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -64,6 +64,11 @@ module Flipper
     def default_config
       self.class.default_config
     end
+
+    # Public: default name of the adapter
+    def name
+      @name ||= self.class.name.split('::').last.split(/(?=[A-Z])/).join('_').downcase.to_sym
+    end
   end
 end
 

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -37,9 +37,6 @@ module Flipper
         See https://github.com/flippercloud/flipper/issues/557
       EOS
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public: Initialize a new ActiveRecord adapter instance.
       #
       # name - The Symbol name for this adapter. Optional (default :active_record)

--- a/lib/flipper/adapters/active_support_cache_store.rb
+++ b/lib/flipper/adapters/active_support_cache_store.rb
@@ -12,13 +12,9 @@ module Flipper
       # Internal
       attr_reader :cache
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public
       def initialize(adapter, cache, expires_in: nil, write_through: false)
         @adapter = adapter
-        @name = :active_support_cache_store
         @cache = cache
         @write_options = {}
         @write_options[:expires_in] = expires_in if expires_in

--- a/lib/flipper/adapters/dalli.rb
+++ b/lib/flipper/adapters/dalli.rb
@@ -11,16 +11,12 @@ module Flipper
       # Internal
       attr_reader :cache
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public: The ttl for all cached data.
       attr_reader :ttl
 
       # Public
       def initialize(adapter, cache, ttl = 0)
         @adapter = adapter
-        @name = :dalli
         @cache = cache
         @ttl = ttl
 

--- a/lib/flipper/adapters/dual_write.rb
+++ b/lib/flipper/adapters/dual_write.rb
@@ -3,8 +3,7 @@ module Flipper
     class DualWrite
       include ::Flipper::Adapter
 
-      # Public: The name of the adapter.
-      attr_reader :name, :local, :remote
+      attr_reader :local, :remote
 
       # Public: Build a new sync instance.
       #
@@ -12,7 +11,6 @@ module Flipper
       # remote - The remote flipper adapter that writes should go to first (in
       #          addition to the local adapter).
       def initialize(local, remote, options = {})
-        @name = :dual_write
         @local = local
         @remote = remote
       end

--- a/lib/flipper/adapters/failover.rb
+++ b/lib/flipper/adapters/failover.rb
@@ -3,9 +3,6 @@ module Flipper
     class Failover
       include ::Flipper::Adapter
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public: Build a new failover instance.
       #
       # primary   - The primary flipper adapter.
@@ -17,7 +14,6 @@ module Flipper
       #             :errors - Array of exception types for which to failover
 
       def initialize(primary, secondary, options = {})
-        @name = :failover
         @primary = primary
         @secondary = secondary
 

--- a/lib/flipper/adapters/failsafe.rb
+++ b/lib/flipper/adapters/failsafe.rb
@@ -3,9 +3,6 @@ module Flipper
     class Failsafe
       include ::Flipper::Adapter
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public: Build a new Failsafe instance.
       #
       # adapter   - Flipper adapter to guard.
@@ -15,7 +12,6 @@ module Flipper
       def initialize(adapter, options = {})
         @adapter = adapter
         @errors = options.fetch(:errors, [StandardError])
-        @name = :failsafe
       end
 
       def features

--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -10,7 +10,7 @@ module Flipper
     class Http
       include Flipper::Adapter
 
-      attr_reader :name, :client
+      attr_reader :client
 
       def initialize(options = {})
         @client = Client.new(url: options.fetch(:url),
@@ -22,7 +22,6 @@ module Flipper
                              write_timeout: options[:write_timeout],
                              max_retries: options[:max_retries],
                              debug_output: options[:debug_output])
-        @name = :http
       end
 
       def get(feature)

--- a/lib/flipper/adapters/instrumented.rb
+++ b/lib/flipper/adapters/instrumented.rb
@@ -13,9 +13,6 @@ module Flipper
       # Private: What is used to instrument all the things.
       attr_reader :instrumenter
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Internal: Initializes a new adapter instance.
       #
       # adapter - Vanilla adapter instance to wrap.
@@ -25,7 +22,6 @@ module Flipper
       #
       def initialize(adapter, options = {})
         @adapter = adapter
-        @name = :instrumented
         @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
       end
 

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -11,16 +11,12 @@ module Flipper
       # Internal
       attr_reader :cache
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Internal: The adapter this adapter is wrapping.
       attr_reader :adapter
 
       # Public
       def initialize(adapter, cache = nil)
         @adapter = adapter
-        @name = :memoizable
         @cache = cache || {}
         @memoize = false
         @features_key = :flipper_features

--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -8,13 +8,9 @@ module Flipper
     class Memory
       include ::Flipper::Adapter
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public
       def initialize(source = nil, threadsafe: true)
         @source = Typecast.features_hash(source)
-        @name = :memory
         @lock = Mutex.new if threadsafe
         reset
       end

--- a/lib/flipper/adapters/moneta.rb
+++ b/lib/flipper/adapters/moneta.rb
@@ -7,13 +7,9 @@ module Flipper
 
       FEATURES_KEY = :flipper_features
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public
       def initialize(moneta)
         @moneta = moneta
-        @name = :moneta
       end
 
       # Public:  The set of known features

--- a/lib/flipper/adapters/mongo.rb
+++ b/lib/flipper/adapters/mongo.rb
@@ -7,15 +7,11 @@ module Flipper
     class Mongo
       include ::Flipper::Adapter
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public: The name of the collection storing the feature data.
       attr_reader :collection
 
       def initialize(collection)
         @collection = collection
-        @name = :mongo
         @features_key = :flipper_features
       end
 

--- a/lib/flipper/adapters/operation_logger.rb
+++ b/lib/flipper/adapters/operation_logger.rb
@@ -34,13 +34,9 @@ module Flipper
       # Internal: An array of the operations that have happened.
       attr_reader :operations
 
-      # Internal: The name of the adapter.
-      attr_reader :name
-
       # Public
       def initialize(adapter, operations = nil)
         @adapter = adapter
-        @name = :operation_logger
         @operations = operations || []
       end
 

--- a/lib/flipper/adapters/poll.rb
+++ b/lib/flipper/adapters/poll.rb
@@ -10,13 +10,11 @@ module Flipper
       # Deprecated
       Poller = ::Flipper::Poller
 
-      # Public: The name of the adapter.
-      attr_reader :name, :adapter, :poller
+      attr_reader :adapter, :poller
 
       def_delegators :synced_adapter, :features, :get, :get_multi, :get_all, :add, :remove, :clear, :enable, :disable
 
       def initialize(poller, adapter)
-        @name = :poll
         @adapter = adapter
         @poller = poller
         @last_synced_at = 0

--- a/lib/flipper/adapters/pstore.rb
+++ b/lib/flipper/adapters/pstore.rb
@@ -10,15 +10,11 @@ module Flipper
     class PStore
       include ::Flipper::Adapter
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public: The path to where the file is stored.
       attr_reader :path
 
       # Public
       def initialize(path = 'flipper.pstore', thread_safe = true)
-        @name = :pstore
         @path = path
         @store = ::PStore.new(path, thread_safe)
         @features_key = :flipper_features

--- a/lib/flipper/adapters/read_only.rb
+++ b/lib/flipper/adapters/read_only.rb
@@ -12,13 +12,9 @@ module Flipper
         end
       end
 
-      # Internal: The name of the adapter.
-      attr_reader :name
-
       # Public
       def initialize(adapter)
         @adapter = adapter
-        @name = :read_only
       end
 
       def features

--- a/lib/flipper/adapters/redis.rb
+++ b/lib/flipper/adapters/redis.rb
@@ -7,9 +7,6 @@ module Flipper
     class Redis
       include ::Flipper::Adapter
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       attr_reader :key_prefix
 
       def features_key
@@ -27,7 +24,6 @@ module Flipper
       #              flipper's Redis keys
       def initialize(client, key_prefix: nil)
         @client = client
-        @name = :redis
         @key_prefix = key_prefix
       end
 

--- a/lib/flipper/adapters/redis_cache.rb
+++ b/lib/flipper/adapters/redis_cache.rb
@@ -11,13 +11,9 @@ module Flipper
       # Internal
       attr_reader :cache
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public
       def initialize(adapter, cache, ttl = 3600)
         @adapter = adapter
-        @name = :redis_cache
         @cache = cache
         @ttl = ttl
 

--- a/lib/flipper/adapters/rollout.rb
+++ b/lib/flipper/adapters/rollout.rb
@@ -11,12 +11,8 @@ module Flipper
         end
       end
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       def initialize(rollout)
         @rollout = rollout
-        @name = :rollout
       end
 
       # Public: The set of known features.

--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -34,12 +34,9 @@ module Flipper
         See https://github.com/flippercloud/flipper/issues/557
       EOS
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public: Initialize a new Sequel adapter instance.
       #
-      # name - The Symbol name for this adapter. Optional (default :active_record)
+      # name - The Symbol name for this adapter. Optional (default :sequel)
       # feature_class - The AR class responsible for the features table.
       # gate_class - The AR class responsible for the gates table.
       #

--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -8,9 +8,6 @@ module Flipper
     class Sync
       include ::Flipper::Adapter
 
-      # Public: The name of the adapter.
-      attr_reader :name
-
       # Public: The synchronizer that will keep the local and remote in sync.
       attr_reader :synchronizer
 
@@ -22,7 +19,6 @@ module Flipper
       # interval - The Float or Integer number of seconds between syncs from
       # remote to local. Default value is set in IntervalSynchronizer.
       def initialize(local, remote, options = {})
-        @name = :sync
         @local = local
         @remote = remote
         @synchronizer = options.fetch(:synchronizer) do


### PR DESCRIPTION
I noticed while working on #760 that every adapter defines `#name` and it's just a variable set in initialize. This PR added a default `Adapter#name` method, which is just the `snake_case` version of the `ClassName`.

In https://github.com/flippercloud/flipper/pull/760#discussion_r1328013132, @jnunemaker said:

> I don't usually allow changing the adapter name. But seeing it makes me wonder if we should allow this for people as I could see scenarios where someone wants to override for instrumentation purposes.

Currently, the ActiveRecord and Sequel adapters are the only ones that allow setting the name. Those will still work with this change. Should we allow others?
