### PR TITLE
Use more-efficient Redis `sismember` command to check if feature exists

### DIFF
--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -43,6 +43,13 @@ module Flipper
       result
     end
 
+    # Public: Does a feature with this key exist.
+    #
+    # Returns true if a feature exists with this key, else false.
+    def exist?(key)
+      features.include?(key)
+    end
+
     # Public: Ensure that adapter is in sync with source adapter provided.
     #
     # source - The source dsl, adapter or export to import.

--- a/lib/flipper/adapters/redis.rb
+++ b/lib/flipper/adapters/redis.rb
@@ -32,6 +32,11 @@ module Flipper
         read_feature_keys
       end
 
+      # Public: Does a feature with this key exist.
+      def exist?(key)
+        @client.sismember(features_key, key)
+      end
+
       # Public: Adds a feature to the set of known features.
       def add(feature)
         if redis_sadd_returns_boolean?

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -79,7 +79,7 @@ module Flipper
     #
     # Returns true if exists in adapter else false.
     def exist?
-      instrument(:exist?) { adapter.features.include?(key) }
+      instrument(:exist?) { adapter.exist?(key) }
     end
 
     # Public: Removes this feature.

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe Flipper::Adapters::Redis do
 
   it_should_behave_like 'a flipper adapter'
 
+  it 'correctly identifies if a with feature with the given name exists' do
+    expect {
+      subject.add(Flipper::Feature.new(:foo, subject))
+    }.to change { subject.exist?(:foo) }.from(false).to(true)
+  end
+
   it 'configures itself on load' do
     Flipper.configuration = nil
     Flipper.instance = nil


### PR DESCRIPTION
We have a fairly large number of features backed by a Redis adapter and use something like that in the discussion in https://github.com/flippercloud/flipper/issues/354 to set default feature values.  I spotted that the `exist?` check `smembers` command was showing up in our [Redis slowlog](https://redis.io/commands/slowlog-get/).

We can use [`sismember` ](https://redis.io/commands/sismember/) instead of pulling back all feature names with [`smembers`](https://redis.io/commands/smembers/) and checking for inclusion. This should go from O(N) (N is the number of features) to O(1), for a modest performance improvement.