### PR TITLE
Hide UI elements when Flipper is in read-only mode

### DIFF
--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -24,6 +24,10 @@ module Flipper
       end
     end
 
+    def read_only?
+      false
+    end
+
     # Public: Get all features and gate values in one call. Defaults to one call
     # to features and another to get_multi. Feel free to override per adapter to
     # make this more efficient.

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -117,6 +117,11 @@ module Flipper
         @adapter.disable(feature, gate, thing).tap { expire_feature(feature) }
       end
 
+      # Public
+      def read_only?
+        @adapter.read_only?
+      end
+
       def import(source)
         @adapter.import(source).tap { cache.clear if memoizing? }
       end

--- a/lib/flipper/adapters/read_only.rb
+++ b/lib/flipper/adapters/read_only.rb
@@ -21,6 +21,10 @@ module Flipper
         @adapter.features
       end
 
+      def read_only?
+        true
+      end
+
       def get(feature)
         @adapter.get(feature)
       end

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -272,6 +272,10 @@ module Flipper
       adapter.features.map { |name| feature(name) }.to_set
     end
 
+    def read_only?
+      adapter.read_only?
+    end
+
     # Cloud DSL method that does nothing for open source version.
     def sync
     end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -276,7 +276,7 @@ module Flipper
 
       # Internal: Method to call when the UI is in read only mode and you want
       # to inform people of that fact.
-      def read_only
+      def render_read_only
         status 403
 
         breadcrumb 'Home', '/'
@@ -284,6 +284,14 @@ module Flipper
         breadcrumb 'Noooooope'
 
         halt view_response(:read_only)
+      end
+
+      def read_only?
+        Flipper::UI.configuration.read_only || flipper.read_only?
+      end
+
+      def write_allowed?
+        !read_only?
       end
 
       def bootstrap_css

--- a/lib/flipper/ui/actions/actors_gate.rb
+++ b/lib/flipper/ui/actions/actors_gate.rb
@@ -23,7 +23,7 @@ module Flipper
         end
 
         def post
-          read_only if Flipper::UI.configuration.read_only
+          read_only if read_only?
 
           feature = flipper[feature_name]
           value = params['value'].to_s.strip

--- a/lib/flipper/ui/actions/actors_gate.rb
+++ b/lib/flipper/ui/actions/actors_gate.rb
@@ -23,7 +23,7 @@ module Flipper
         end
 
         def post
-          read_only if read_only?
+          render_read_only if read_only?
 
           feature = flipper[feature_name]
           value = params['value'].to_s.strip

--- a/lib/flipper/ui/actions/add_feature.rb
+++ b/lib/flipper/ui/actions/add_feature.rb
@@ -8,7 +8,7 @@ module Flipper
         route %r{\A/features/new/?\Z}
 
         def get
-          read_only if Flipper::UI.configuration.read_only
+          render_read_only if read_only?
 
           unless Flipper::UI.configuration.feature_creation_enabled
             status 403

--- a/lib/flipper/ui/actions/boolean_gate.rb
+++ b/lib/flipper/ui/actions/boolean_gate.rb
@@ -10,7 +10,7 @@ module Flipper
         route %r{\A/features/(?<feature_name>.*)/boolean/?\Z}
 
         def post
-          read_only if Flipper::UI.configuration.read_only
+          render_read_only if read_only?
 
           feature = flipper[feature_name]
           @feature = Decorators::Feature.new(feature)

--- a/lib/flipper/ui/actions/feature.rb
+++ b/lib/flipper/ui/actions/feature.rb
@@ -26,7 +26,7 @@ module Flipper
         end
 
         def delete
-          read_only if Flipper::UI.configuration.read_only
+          render_read_only if read_only?
 
           unless Flipper::UI.configuration.feature_removal_enabled
             status 403

--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -36,7 +36,7 @@ module Flipper
         end
 
         def post
-          read_only if Flipper::UI.configuration.read_only
+          render_read_only if read_only?
 
           unless Flipper::UI.configuration.feature_creation_enabled
             status 403

--- a/lib/flipper/ui/actions/groups_gate.rb
+++ b/lib/flipper/ui/actions/groups_gate.rb
@@ -22,7 +22,7 @@ module Flipper
         end
 
         def post
-          read_only if Flipper::UI.configuration.read_only
+          render_read_only if read_only?
 
           feature = flipper[feature_name]
           value = params['value'].to_s.strip

--- a/lib/flipper/ui/actions/percentage_of_actors_gate.rb
+++ b/lib/flipper/ui/actions/percentage_of_actors_gate.rb
@@ -10,7 +10,7 @@ module Flipper
         route %r{\A/features/(?<feature_name>.*)/percentage_of_actors/?\Z}
 
         def post
-          read_only if Flipper::UI.configuration.read_only
+          render_read_only if read_only?
 
           feature = flipper[feature_name]
           @feature = Decorators::Feature.new(feature)

--- a/lib/flipper/ui/actions/percentage_of_time_gate.rb
+++ b/lib/flipper/ui/actions/percentage_of_time_gate.rb
@@ -10,7 +10,7 @@ module Flipper
         route %r{\A/features/(?<feature_name>.*)/percentage_of_time/?\Z}
 
         def post
-          read_only if Flipper::UI.configuration.read_only
+          render_read_only if read_only?
 
           feature = flipper[feature_name]
           @feature = Decorators::Feature.new(feature)

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -40,7 +40,7 @@
                 </strong>
               </h6>
             </div>
-            <% unless Flipper::UI.configuration.read_only %>
+            <% if write_allowed? %>
               <div class="col col-auto toggle-block-when-off">
                 <button class="btn btn-outline-secondary js-toggle-trigger" data-toggle="collapse" data-target="#add-actor">Add an actor</button>
               </div>
@@ -73,7 +73,7 @@
                 </h6>
               </div>
               <div class="col col-auto">
-                <% unless Flipper::UI.configuration.read_only %>
+                <% if write_allowed? %>
                   <form action="<%= script_name %>/features/<%= @feature.key %>/actors" method="post">
                     <%== csrf_input_tag %>
                     <input type="hidden" name="operation" value="disable">
@@ -102,7 +102,7 @@
                 </strong>
               </h6>
             </div>
-            <% unless Flipper::UI.configuration.read_only %>
+            <% if write_allowed? %>
               <div class="col col-auto toggle-block-when-off">
                 <button class="btn btn-outline-secondary js-toggle-trigger" data-toggle="collapse" data-target="#add-actor">Add a group</button>
               </div>
@@ -138,7 +138,7 @@
                 <h6 class="m-0"><%= item %></h6>
               </div>
               <div class="col col-auto">
-                <% unless Flipper::UI.configuration.read_only %>
+                <% if write_allowed? %>
                   <form action="<%= script_name %>/features/<%= @feature.key %>/groups" method="post">
                     <%== csrf_input_tag %>
                     <input type="hidden" name="operation" value="disable">
@@ -160,7 +160,7 @@
               <div class="col col-mr-auto">
                 <h6 class="m-0"><strong class="<%= "text-muted" unless @feature.percentage_of_actors_value > 0 %>">Enabled for <%= @feature.percentage_of_actors_value %>% of actors</strong></h6>
               </div>
-              <% unless Flipper::UI.configuration.read_only %>
+              <% if write_allowed? %>
                 <div class="col col-auto toggle-block-when-off">
                   <button class="btn btn-outline-secondary js-toggle-trigger">Edit</button>
                 </div>
@@ -171,7 +171,7 @@
             </div>
           </div>
 
-          <% unless Flipper::UI.configuration.read_only %>
+          <% if write_allowed? %>
             <div class="card-body border-bottom toggle-block-when-on bg-lightest">
               <div class="row">
                 <div class="col-12 col-md-6 mb-3 mb-md-0">
@@ -203,7 +203,7 @@
               <div class="col col-mr-auto">
                 <h6 class="m-0"><strong class="<%= "text-muted" unless @feature.percentage_of_time_value > 0 %>">Enabled for <%= @feature.percentage_of_time_value %>% of time</strong></h6>
               </div>
-              <% unless Flipper::UI.configuration.read_only %>
+              <% if write_allowed? %>
                 <div class="col col-auto toggle-block-when-off">
                   <button class="btn btn-outline-secondary js-toggle-trigger">Edit</button>
                 </div>
@@ -214,7 +214,7 @@
             </div>
           </div>
 
-          <% unless Flipper::UI.configuration.read_only %>
+          <% if write_allowed? %>
             <div class="card-body border-bottom toggle-block-when-on bg-lightest">
               <div class="row">
                 <div class="col-12 col-md-6 mb-3 mb-md-0">
@@ -240,52 +240,45 @@
         </div>
       <% end %>
 
-      <div class="card-body">
-        <form action="<%= script_name %>/features/<%= @feature.key %>/boolean" method="post">
-          <%== csrf_input_tag %>
+      <% if write_allowed? %>
+        <div class="card-body">
+          <form action="<%= script_name %>/features/<%= @feature.key %>/boolean" method="post">
+            <%== csrf_input_tag %>
 
-          <div class="row">
-            <% unless @feature.boolean_value %>
-              <div class="col">
-                <button type="submit" name="action" value="Enable" <% if Flipper::UI.configuration.confirm_fully_enable %>id="enable_feature__button"<% end %> class="btn btn-outline-success btn-block" <% if Flipper::UI.configuration.read_only %>disabled<% end %>>
-                  <span class="d-block" data-toggle="tooltip"
-                    <% if Flipper::UI.configuration.confirm_fully_enable %>
-                      data-confirmation-text="<%= feature_name %>"
-                    <% end %>
-                    <% if Flipper::UI.configuration.read_only %>
-                      title="Fully enable is not allowed in read only mode."
-                    <% else %>
-                      title="Enable for everyone"
-                    <% end %>
-                    >
-                    Fully Enable
-                  </span>
-                </button>
-              </div>
-            <% end %>
+            <div class="row">
+              <% unless @feature.boolean_value %>
+                <div class="col">
+                  <button type="submit" name="action" value="Enable" <% if Flipper::UI.configuration.confirm_fully_enable %>id="enable_feature__button"<% end %> class="btn btn-outline-success btn-block">
+                    <span class="d-block" data-toggle="tooltip"
+                      <% if Flipper::UI.configuration.confirm_fully_enable %>
+                        data-confirmation-text="<%= feature_name %>"
+                      <% end %>
+                        title="Enable for everyone"
+                      >
+                      Fully Enable
+                    </span>
+                  </button>
+                </div>
+              <% end %>
 
-            <% unless @feature.off? %>
-              <div class="col">
-                <button type="submit" name="action" value="Disable" class="btn btn-outline-danger btn-block" <% if Flipper::UI.configuration.read_only %>disabled<% end %>>
-                  <span class="d-block" data-toggle="tooltip"
-                    <% if Flipper::UI.configuration.read_only %>
-                      title="Disable is not allowed in read only mode.">
-                    <% else %>
-                      title="Disable for everyone by clearing all percentages, groups and actors.">
-                    <% end %>
-                    Disable
-                  </span>
-                </button>
-              </div>
-            <% end %>
-          </div>
-        </form>
-      </div>
+              <% unless @feature.off? %>
+                <div class="col">
+                  <button type="submit" name="action" value="Disable" class="btn btn-outline-danger btn-block">
+                    <span class="d-block" data-toggle="tooltip" title="Disable for everyone by clearing all percentages, groups and actors.">
+                      Disable
+                    </span>
+                  </button>
+                </div>
+              <% end %>
+            </div>
+          </form>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>
 
-<% if !Flipper::UI.configuration.read_only && Flipper::UI.configuration.feature_removal_enabled %>
+<% if write_allowed? && Flipper::UI.configuration.feature_removal_enabled %>
   <div class="row">
     <div class="col">
       <div class="card border">

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -3,7 +3,7 @@
     <% if Flipper::UI.configuration.fun %>
       <h4>But I've got a blank space baby...</h4>
       <p>And I'll flip your features.</p>
-      <%- if !Flipper::UI.configuration.read_only && Flipper::UI.configuration.feature_creation_enabled -%>
+      <%- if write_allowed? && Flipper::UI.configuration.feature_creation_enabled -%>
         <p>
           <a class="btn btn-primary btn-sm" href="<%= script_name %>/features/new">Add Feature</a>
         </p>
@@ -11,7 +11,7 @@
     <% else %>
       <h4>Getting Started</h4>
       <p class="mb-1">You have not added any features to configure yet.</p>
-      <%- if !Flipper::UI.configuration.read_only && Flipper::UI.configuration.feature_creation_enabled -%>
+      <%- if write_allowed? && Flipper::UI.configuration.feature_creation_enabled -%>
         <p class="mt-2">
           <a class="btn btn-primary btn-sm" href="<%= script_name %>/features/new">Add Feature</a>
         </p>
@@ -26,7 +26,7 @@
 <% else %>
   <div class="card">
     <div class="card-header">
-      <%- if !Flipper::UI.configuration.read_only && Flipper::UI.configuration.feature_creation_enabled -%>
+      <%- if write_allowed? && Flipper::UI.configuration.feature_creation_enabled -%>
         <div class="float-right">
           <a class="btn btn-primary btn-sm" href="<%= script_name %>/features/new">Add Feature</a>
         </div>

--- a/lib/flipper/ui/views/read_only.erb
+++ b/lib/flipper/ui/views/read_only.erb
@@ -1,3 +1,11 @@
 <div class="alert alert-danger">
-  The UI is currently in read only mode. To change this, you'll need to set <code>Flipper::UI.configuration.read_only = false</code> wherever flipper is running from.
+  <p>The UI is currently in read only mode.</p>
+
+  <p>
+    To change this, you'll need to set <code>Flipper::UI.configuration.read_only = false</code> wherever flipper is running from.
+  </p>
+
+  <p>
+    Alternatively, you may be using the <code>Flipper::Adapters::ReadOnly</code> adapter. This will also set Flipper into read only mode.
+  </p>
 </div>

--- a/spec/flipper/adapters/read_only_spec.rb
+++ b/spec/flipper/adapters/read_only_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe Flipper::Adapters::ReadOnly do
     expect(subject.features).to eq(Set['stats'])
   end
 
+  it 'is configured as read only' do
+    expect(subject.read_only?).to eq(true)
+  end
+
   it 'raises error on add' do
     expect { subject.add(feature) }.to raise_error(Flipper::Adapters::ReadOnly::WriteAttempted)
   end

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -129,6 +129,23 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
       end
     end
 
+    context "when a readonly adapter is configured" do
+      let(:value) { 'User;6' }
+
+      before do
+        allow(flipper).to receive(:read_only?) { true }
+      end
+
+      it "does not allow an actor to be added" do
+        post 'features/search/actors',
+           { 'value' => value, 'operation' => 'enable', 'authenticity_token' => token },
+           'rack.session' => session
+
+        expect(flipper[:search].actors_value).not_to include('User;6')
+        expect(last_response.body).to include("The UI is currently in read only mode.")
+      end
+    end
+
     context 'disabling an actor' do
       let(:value) { 'User;6' }
       let(:multi_value) { 'User;5, User;7, User;9, User;12' }

--- a/spec/flipper/ui/actions/add_feature_spec.rb
+++ b/spec/flipper/ui/actions/add_feature_spec.rb
@@ -39,4 +39,24 @@ RSpec.describe Flipper::UI::Actions::AddFeature do
       expect(last_response.body).to include('Feature creation is disabled.')
     end
   end
+
+  describe 'GET /features/new when an adpter is set to readonly' do
+    before do
+      @original_feature_creation_enabled = Flipper::UI.configuration.feature_creation_enabled
+      Flipper::UI.configuration.feature_creation_enabled = false
+      get '/features/new'
+    end
+
+    after do
+      Flipper::UI.configuration.feature_creation_enabled = @original_feature_creation_enabled
+    end
+
+    it 'returns 403' do
+      expect(last_response.status).to be(403)
+    end
+
+    it 'renders feature creation disabled template' do
+      expect(last_response.body).to include('Feature creation is disabled.')
+    end
+  end
 end

--- a/spec/flipper/ui/actions/add_feature_spec.rb
+++ b/spec/flipper/ui/actions/add_feature_spec.rb
@@ -42,21 +42,16 @@ RSpec.describe Flipper::UI::Actions::AddFeature do
 
   describe 'GET /features/new when an adpter is set to readonly' do
     before do
-      @original_feature_creation_enabled = Flipper::UI.configuration.feature_creation_enabled
-      Flipper::UI.configuration.feature_creation_enabled = false
+      allow(flipper).to receive(:read_only?) { true }
       get '/features/new'
-    end
-
-    after do
-      Flipper::UI.configuration.feature_creation_enabled = @original_feature_creation_enabled
     end
 
     it 'returns 403' do
       expect(last_response.status).to be(403)
     end
 
-    it 'renders feature creation disabled template' do
-      expect(last_response.body).to include('Feature creation is disabled.')
+    it 'shows that the UI is currently read-only mode' do
+      expect(last_response.body).to include('The UI is currently in read only mode.')
     end
   end
 end

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -113,6 +113,18 @@ RSpec.describe Flipper::UI::Actions::Feature do
       expect(last_response.body).to include('Most in-depth search')
     end
 
+    context "when in read-only mode" do
+      before do
+        allow(flipper).to receive(:read_only?) { true }
+      end
+
+      before { get '/features' }
+
+      it 'renders template with no buttons or ways to modify a feature' do
+        expect(last_response.body).not_to include("Fully Enable")
+      end
+    end
+
     context 'custom actor names' do
       before do
         actor = Flipper::Actor.new('some_actor_name')
@@ -126,7 +138,7 @@ RSpec.describe Flipper::UI::Actions::Feature do
             }
           }
         end
-        
+
         get '/features/search'
       end
 

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -64,6 +64,20 @@ RSpec.describe Flipper::UI::Actions::Features do
         end
       end
     end
+
+    context "when in read-only mode" do
+      before { allow(flipper).to receive(:read_only?) { true}}
+
+      before { get '/features' }
+
+      it 'responds with success' do
+        expect(last_response.status).to be(200)
+      end
+
+      it 'renders template with no button' do
+        expect(last_response.body).not_to include('<a class="btn btn-primary btn-sm" href="/features/new">Add Feature</a>')
+      end
+    end
   end
 
   describe 'POST /features' do

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Flipper::UI::Actions::Features do
     end
 
     context "when in read-only mode" do
-      before { allow(flipper).to receive(:read_only?) { true}}
+      before { allow(flipper).to receive(:read_only?) { true } }
 
       before { get '/features' }
 


### PR DESCRIPTION
We have a particular business-critical application that uses Flipper flags, and we would like to provide a completely read-only UI with Flipper. I know of a way to do this, which is to set `Flipper::UI`'s configuration to be read only. However, this same application is a bit a "nexus" for some smaller apps, and therefore we have multiple instances of `Flipper::UI` at play here. The different instances each control the flipper flags for the different applications. 

I was able to see that there's a `ReadOnly` adapter however:

```
readonly_app = Flipper::UI.app(Flipper.new(Flipper::Adapters::ReadOnly.new(connection)))
```

But this doesn't hide all the UI buttons in Flipper UI. Here's what I see in that app by default:

![image](https://github.com/flippercloud/flipper/assets/2687/1c19af02-939e-489e-9b02-448f2c1b253f)

Having all the buttons and forms present makes our security people uncomfortable.

---

So what I've tried to do in this PR is to cut out all of the UI that performs a write action, which then cuts the page down to this:

![image](https://github.com/flippercloud/flipper/assets/2687/02b3a688-6c44-4984-ad06-155fa32cbfd5)

And the homepage to this:

![image](https://github.com/flippercloud/flipper/assets/2687/c8740795-af49-4163-93f3-9b133e10c2fd)

I've also updated the "nooooope" error screen to show that the `ReadOnly` adapter might be in use:

![image](https://github.com/flippercloud/flipper/assets/2687/dd0c8973-0166-4f15-a761-42418c1b1418)
