### PR TITLE
Handle deprecation of Rack::File in Rack 3.1

### DIFF
--- a/lib/flipper/ui/actions/file.rb
+++ b/lib/flipper/ui/actions/file.rb
@@ -8,7 +8,8 @@ module Flipper
         route %r{(images|css|js)/.*\Z}
 
         def get
-          Rack::File.new(public_path).call(request.env)
+          klass = Rack.release >= "2.1" ? Rack::Files : Rack::File
+          klass.new(public_path).call(request.env)
         end
       end
     end

--- a/lib/flipper/ui/actions/file.rb
+++ b/lib/flipper/ui/actions/file.rb
@@ -1,4 +1,8 @@
-require 'rack/file'
+if Rack.release >= "2.1"
+  require 'rack/files'
+else
+  require 'rack/file'
+end
 require 'flipper/ui/action'
 
 module Flipper


### PR DESCRIPTION
When using Rack >= 3.0.0 you get this error message on boot an app with Flipper UI :

```
warning: Rack::File is deprecated and will be removed in Rack 3.1
```

This PR detects if `Rack::Files` is available and tries to use it instead.

Closes https://github.com/flippercloud/flipper/issues/769

[Rack deprecation source](https://github.com/rack/rack/pull/1720)