### PR TITLE
statsd config

### DIFF
--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -54,5 +54,15 @@ module Flipper
         @default.call
       end
     end
+
+    def statsd
+      require 'flipper/instrumentation/statsd_subscriber'
+      Flipper::Instrumentation::StatsdSubscriber.client
+    end
+
+    def statsd=(client)
+      require "flipper/instrumentation/statsd"
+      Flipper::Instrumentation::StatsdSubscriber.client = client
+    end
   end
 end

--- a/spec/flipper/configuration_spec.rb
+++ b/spec/flipper/configuration_spec.rb
@@ -30,4 +30,21 @@ RSpec.describe Flipper::Configuration do
       expect(subject.default).to be(instance)
     end
   end
+
+  describe '#statsd' do
+    let(:statsd) { double(Statsd) }
+
+    after do
+      Flipper::Instrumentation::StatsdSubscriber.client = nil
+    end
+
+    it 'returns nil by default' do
+      expect(subject.statsd).to be_nil
+    end
+
+    it 'can be set' do
+      subject.statsd = statsd
+      expect(subject.statsd).to be(statsd)
+    end
+  end
 end

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -1,6 +1,5 @@
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumentation/statsd'
-require 'statsd'
 
 begin
   require 'active_support/isolated_execution_state'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'bundler'
 Bundler.setup(:default)
 
 require 'debug'
+require 'statsd'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
following up on our discussion in https://github.com/flippercloud/flipper/pull/778 to enable

```ruby
Flipper.configure do |conf|
  conf.statsd = my_client
end
```

this would simplify statsd integration and abstract away the subscriber logic.  I don't love the embedded requires and have an idea to rework that if we'd like.  we may want to put `ActiveSupport::Notifications.subscribe` into a method and pair it with a way to unsubscribe, so that it can be done multiple times (especially for testing)

