### PR TITLE
Include client framework versions in API requests

### DIFF
--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -114,7 +114,7 @@ module Flipper
         end
 
         def client_frameworks
-          CLIENT_FRAMEWORKS.transform_values(&:call).select { |_, version| version }
+          CLIENT_FRAMEWORKS.transform_values { |detect| detect.call rescue nil }.select { |_, version| version }
         end
       end
     end

--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -14,6 +14,12 @@ module Flipper
 
         HTTPS_SCHEME = "https".freeze
 
+        CLIENT_FRAMEWORKS = {
+          rails: -> { Rails.version if defined?(Rails) },
+          sinatra: -> { Sinatra::VERSION if defined?(Sinatra) },
+          hanami: -> { Hanami::VERSION if defined?(Hanami) },
+        }
+
         attr_reader :uri, :headers
         attr_reader :basic_auth_username, :basic_auth_password
         attr_reader :read_timeout, :open_timeout, :write_timeout, :max_retries, :debug_output
@@ -93,6 +99,11 @@ module Flipper
           body = options[:body]
           request = http_method.new(uri.request_uri)
           request.initialize_http_header(request_headers)
+
+          client_frameworks.each do |framework, version|
+            request.add_field("Client-Framework", [framework, version].join("="))
+          end
+
           request.body = body if body
 
           if @basic_auth_username && @basic_auth_password
@@ -100,6 +111,10 @@ module Flipper
           end
 
           request
+        end
+
+        def client_frameworks
+          CLIENT_FRAMEWORKS.transform_values(&:call).select { |_, version| version }
         end
       end
     end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -90,6 +90,40 @@ RSpec.describe Flipper::Adapters::Http do
     adapter.get(flipper[:feature_panel])
   end
 
+  it "sends framework versions" do
+    stub_const("Rails", Struct.new(:version).new("7.1.0"))
+    stub_const("Sinatra::VERSION", "3.1.0")
+    stub_const("Hanami::VERSION", "0.7.2")
+
+    headers = {
+      "Client-Framework" => ["rails=7.1.0", "sinatra=3.1.0", "hanami=0.7.2"]
+    }
+
+    stub_request(:get, "http://app.com/flipper/features/feature_panel")
+      .with(headers: headers)
+      .to_return(status: 404, body: "", headers: {})
+
+    adapter = described_class.new(url: 'http://app.com/flipper')
+    adapter.get(flipper[:feature_panel])
+  end
+
+  it "does not send undefined framework versions" do
+    stub_const("Rails", Struct.new(:version).new("7.1.0"))
+    stub_const("Sinatra::VERSION", "3.1.0")
+
+    headers = {
+      "Client-Framework" => ["rails=7.1.0", "sinatra=3.1.0"]
+    }
+
+    stub_request(:get, "http://app.com/flipper/features/feature_panel")
+      .with(headers: headers)
+      .to_return(status: 404, body: "", headers: {})
+
+    adapter = described_class.new(url: 'http://app.com/flipper')
+    adapter.get(flipper[:feature_panel])
+  end
+
+
   describe "#get" do
     it "raises error when not successful response" do
       stub_request(:get, "http://app.com/flipper/features/feature_panel")

--- a/spec/flipper/cloud/telemetry/submitter_spec.rb
+++ b/spec/flipper/cloud/telemetry/submitter_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe Flipper::Cloud::Telemetry::Submitter do
         'User-Agent' => "Flipper HTTP Adapter v#{Flipper::VERSION}",
       }
       stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
-        with { |request|
+        with(headers: expected_headers) { |request|
           gunzipped = Flipper::Typecast.from_gzip(request.body)
           body = Flipper::Typecast.from_json(gunzipped)
-          body == expected_body && request.headers == expected_headers
+          body == expected_body
         }.to_return(status: 200, body: "{}", headers: {})
       subject.call(enabled_metrics)
     end


### PR DESCRIPTION
Sends Rails, Sinatra, and Hanami versions so we can prioritize which versions to support.

cc #776 