### PR TITLE
Load Cloud secrets from Rails credentials

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,15 @@ All notable changes to this project will be documented in this file.
     conf.statsd = my_client
   end
   ```
+* Load cloud secrets from Rails credentials (https://github.com/flippercloud/flipper/pull/782)
+  ```bash
+  $ rails credentials:edit
+  ```
+  ```yaml
+  flipper:
+    cloud_token: <your-cloud-token>
+    cloud_sync_secret: <your-webhook-secret>
+  ```
 
 ## 1.0.0
 

--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -23,6 +23,10 @@ module Flipper
     end
 
     initializer "flipper.default", before: :load_config_initializers do |app|
+      # Load cloud secrets from Rails credentials
+      ENV["FLIPPER_CLOUD_TOKEN"] ||= app.credentials.dig(:flipper, :cloud_token)
+      ENV["FLIPPER_CLOUD_SYNC_SECRET"] ||= app.credentials.dig(:flipper, :cloud_sync_secret)
+
       require 'flipper/cloud' if cloud?
 
       Flipper.configure do |config|

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::Engine do
     Class.new(Rails::Application) do
       config.eager_load = false
       config.logger = ActiveSupport::Logger.new($stdout)
-    end
+    end.instance
   end
 
   before do
@@ -244,12 +244,12 @@ RSpec.describe Flipper::Engine do
 
   context 'with cloud secrets in Rails.credentials' do
     before do
-      application.credentials = {
+      allow(application).to receive(:credentials).and_return({
         flipper: {
           cloud_token: "credentials-token",
           cloud_sync_secret: "credentials-secret",
         }
-      }
+      })
     end
 
     it "enables cloud" do

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -243,9 +243,23 @@ RSpec.describe Flipper::Engine do
   end
 
   context 'with cloud secrets in Rails.credentials' do
+    around do |example|
+      # Create temporary directory for Rails.root to write credentials to
+      # Once Rails 5.2 support is dropped, this can all be replaced with
+      # `config.credentials.content_path = Tempfile.new.path`
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          Dir.mkdir("#{dir}/config")
+
+          example.run
+        end
+      end
+    end
+
     before do
+      # Set master key which is needed to write credentials
       ENV["RAILS_MASTER_KEY"] = "a" * 32
-      application.config.credentials.content_path = Tempfile.new.path
+
       application.credentials.write(YAML.dump({
         flipper: {
           cloud_token: "credentials-token",

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -242,6 +242,24 @@ RSpec.describe Flipper::Engine do
     end
   end
 
+  context 'with cloud secrets in Rails.credentials' do
+    before do
+      application.credentials = {
+        flipper: {
+          cloud_token: "credentials-token",
+          cloud_sync_secret: "credentials-secret",
+        }
+      }
+    end
+
+    it "enables cloud" do
+      application.initialize!
+      expect(ENV["FLIPPER_CLOUD_TOKEN"]).to eq("credentials-token")
+      expect(ENV["FLIPPER_CLOUD_SYNC_SECRET"]).to eq("credentials-secret")
+      expect(Flipper.instance).to be_a(Flipper::Cloud::DSL)
+    end
+  end
+
   it "includes model methods" do
     subject
     require 'active_record'

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -244,12 +244,14 @@ RSpec.describe Flipper::Engine do
 
   context 'with cloud secrets in Rails.credentials' do
     before do
-      allow(application).to receive(:credentials).and_return({
+      ENV["RAILS_MASTER_KEY"] = "a" * 32
+      application.config.credentials.content_path = Tempfile.new.path
+      application.credentials.write(YAML.dump({
         flipper: {
           cloud_token: "credentials-token",
           cloud_sync_secret: "credentials-secret",
         }
-      })
+      }))
     end
 
     it "enables cloud" do


### PR DESCRIPTION
This allows setting Flipper Cloud secrets via [Rails credentials](https://edgeguides.rubyonrails.org/security.html#custom-credentials)

```
$ rails credentials:edit
```

```
flipper:
  cloud_token: <your-cloud-token>
  cloud_sync_secret: <your-webhook-secret>
```