### PR TITLE
Add #features_for_actor to return all enabeld features for a given actor

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -63,7 +63,7 @@ module Flipper
                  :enable_group, :disable_group,
                  :enable_percentage_of_actors, :disable_percentage_of_actors,
                  :enable_percentage_of_time, :disable_percentage_of_time,
-                 :features, :feature, :[], :preload, :preload_all,
+                 :features, :feature, :features_for_actor, :[], :preload, :preload_all,
                  :adapter, :add, :exist?, :remove, :import, :export,
                  :memoize=, :memoizing?, :read_only?,
                  :sync, :sync_secret # For Flipper::Cloud. Will error for OSS Flipper.

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -76,6 +76,16 @@ module Flipper
       feature(name).enable_actor(actor)
     end
 
+    # Public: All Enabled features for an actor.
+    #
+    # actor - a Flipper::Types::Actor instance or an object that responds
+    #         to flipper_id.
+    #
+    # Returns Set of Flipper::Feature instances.
+    def features_for_actor(actor)
+      adapter.features.keep_if { |feature_name| enabled?(feature_name, actor) }.to_set { |name| feature(name) }
+    end
+
     # Public: Enable a feature for a group.
     #
     # name - The String or Symbol name of the feature.
@@ -269,7 +279,7 @@ module Flipper
     #
     # Returns Set of Flipper::Feature instances.
     def features
-      adapter.features.map { |name| feature(name) }.to_set
+      adapter.features.to_set { |name| feature(name) }
     end
 
     # Public: Does this adapter support writes or not.

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -171,6 +171,30 @@ RSpec.describe Flipper::DSL do
       end
     end
   end
+  describe '#features_for_actor' do
+    actor = Flipper::Actor.new(5)
+    context 'with no features' do
+      it 'defaults to empty set' do
+        expect(subject.features_for_actor(actor)).to eq(Set.new)
+      end
+    end
+
+    context 'with features enabled and disabled' do
+      before do
+        subject.enable_actor(:stats, actor)
+        subject.enable_actor(:cache, actor)
+        subject[:search].disable
+      end
+
+      it 'returns set of feature instances' do
+        expect(subject.features_for_actor(actor)).to be_instance_of(Set)
+        subject.features_for_actor(actor).each do |feature|
+          expect(feature).to be_instance_of(Flipper::Feature)
+        end
+        expect(subject.features_for_actor(actor).map(&:name).map(&:to_s).sort).to eq(%w(cache stats))
+      end
+    end
+  end
 
   describe '#enable/disable' do
     it 'enables and disables the feature' do


### PR DESCRIPTION
Adds #features_for_actor

With this change, you can get all features for the given actor as a param.

I've found we need that feature on my team,  where we just load all the features once.

Please feel free to share your comments and thoughts,
Probably there's a better way to do it.

Thanks for the great work.
