### PR TITLE
Fix: Define default_strict_value on class instead of delegating to instance

### DIFF
--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -70,7 +70,7 @@ module Flipper
       !!ENV["FLIPPER_CLOUD_TOKEN"]
     end
 
-    def default_strict_value
+    def self.default_strict_value
       value = ENV["FLIPPER_STRICT"]
       if value.in?(["warn", "raise", "noop"])
         value.to_sym


### PR DESCRIPTION
`Flipper::Engine.default_strict_value` should delegate to `#instance`, but at least one person experienced an issue where it wasn't. This just makes it a class method so it doesn't have to rely on delegation.