### PR TITLE
UI: show a badges for new releases and deprecations

### DIFF
--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -35,4 +35,6 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'concurrent-ruby', '< 2'
+
+  gem.required_ruby_version = ">= #{Flipper::REQUIRED_RUBY_VERSION}"
 end

--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -83,5 +83,11 @@ module Flipper
         :warn
       end
     end
+
+    NEXT_REQUIRED_RAILS_VERSION = '6.1.0'.freeze
+
+    def self.deprecated_rails_version?
+      Gem::Version.new(Rails.version) < Gem::Version.new(NEXT_REQUIRED_RAILS_VERSION)
+    end
   end
 end

--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -84,10 +84,8 @@ module Flipper
       end
     end
 
-    NEXT_REQUIRED_RAILS_VERSION = '6.1.0'.freeze
-
     def self.deprecated_rails_version?
-      Gem::Version.new(Rails.version) < Gem::Version.new(NEXT_REQUIRED_RAILS_VERSION)
+      Gem::Version.new(Rails.version) < Gem::Version.new(Flipper::NEXT_REQUIRED_RAILS_VERSION)
     end
   end
 end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -53,7 +53,7 @@ module Flipper
         style-src 'self' 'unsafe-inline';
         style-src-attr 'unsafe-inline' ;
         style-src-elem 'self';
-        connect-src https://rubygems.org;
+        connect-src https://www.flippercloud.io;
       CSP
 
       # Public: Call this in subclasses so the action knows its route.

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -53,6 +53,7 @@ module Flipper
         style-src 'self' 'unsafe-inline';
         style-src-attr 'unsafe-inline' ;
         style-src-elem 'self';
+        connect-src https://rubygems.org;
       CSP
 
       # Public: Call this in subclasses so the action knows its route.

--- a/lib/flipper/ui/public/js/version.js
+++ b/lib/flipper/ui/public/js/version.js
@@ -1,0 +1,32 @@
+// Get the latest release from RubyGems.org and show a badge if it's not the current version
+function checkLatestRelease() {
+  // Skip check if last check was less than 1 day ago
+  if(localStorage.getItem('flipper.releaseCheckedAt') > new Date().getTime() - 86400000) return
+
+  fetch('https://rubygems.org/api/v1/gems/flipper.json').then(response => {
+    // Something went wrong, so just give up
+    if(!response.ok) return
+
+    response.json().then(release => {
+      localStorage.setItem('flipper.release', JSON.stringify(release))
+      // store the last time we checked for a new version
+      localStorage.setItem('flipper.releaseCheckedAt', new Date().getTime())
+      showReleaseBadge()
+    })
+  })
+}
+
+// Show a badge if a new release is available
+function showReleaseBadge() {
+  const badge = document.querySelector('#new-version-badge')
+  const release = JSON.parse(localStorage.getItem('flipper.release') || false)
+
+  if(!badge || !release || badge.dataset.version === release.version) return
+
+  badge.innerText = `${release.version} available!`
+  badge.setAttribute('href', release.metadata.changelog_uri)
+  badge.classList.remove('d-none')
+}
+
+checkLatestRelease()
+showReleaseBadge()

--- a/lib/flipper/ui/public/js/version.js
+++ b/lib/flipper/ui/public/js/version.js
@@ -3,14 +3,15 @@ function checkLatestRelease() {
   // Skip check if last check was less than 1 day ago
   if(localStorage.getItem('flipper.releaseCheckedAt') > new Date().getTime() - 86400000) return
 
-  fetch('https://rubygems.org/api/v1/gems/flipper.json').then(response => {
+  // store the last time we checked for a new version
+  localStorage.setItem('flipper.releaseCheckedAt', new Date().getTime())
+
+  fetch('https://www.flippercloud.io/release.json').then(response => {
     // Something went wrong, so just give up
     if(!response.ok) return
 
     response.json().then(release => {
       localStorage.setItem('flipper.release', JSON.stringify(release))
-      // store the last time we checked for a new version
-      localStorage.setItem('flipper.releaseCheckedAt', new Date().getTime())
       showReleaseBadge()
     })
   })
@@ -24,7 +25,7 @@ function showReleaseBadge() {
   if(!badge || !release || badge.dataset.version === release.version) return
 
   badge.innerText = `${release.version} available!`
-  badge.setAttribute('href', release.metadata.changelog_uri)
+  badge.setAttribute('href', release.changelog_uri)
   badge.classList.remove('d-none')
 }
 

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -29,6 +29,12 @@
             Ruby <%= RUBY_VERSION %> deprecated
           </a>
         <% end %>
+
+        <% if defined?(Rails) && Flipper::Engine.deprecated_rails_version? %>
+          <a href="https://github.com/flippercloud/flipper/pull/776" class="badge badge-danger ml-2" style="font-size:100%">
+            Rails <%= Rails.version %> deprecated
+          </a>
+        <% end %>
       </div>
 
       <nav aria-label="breadcrumb">

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -23,6 +23,12 @@
         Version: <%= Flipper::VERSION %>
         <a href="#" class="badge badge-warning ml-2 d-none" style="font-size:100%" id="new-version-badge" data-version="<%= Flipper::VERSION %>">
         </a>
+
+        <% if Flipper.deprecated_ruby_version? %>
+          <a href="https://github.com/flippercloud/flipper/pull/776" class="badge badge-danger ml-2" style="font-size:100%">
+            Ruby <%= RUBY_VERSION %> deprecated
+          </a>
+        <% end %>
       </div>
 
       <nav aria-label="breadcrumb">

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -74,7 +74,7 @@
     <script src="<%= script_name + jquery_js[:src] %>" integrity="<%= jquery_js[:hash] %>" crossorigin="anonymous"></script>
     <script src="<%= script_name + popper_js[:src] %>" integrity="<%= popper_js[:hash] %>" crossorigin="anonymous"></script>
     <script src="<%= script_name + bootstrap_js[:src] %>" integrity="<%= bootstrap_js[:hash] %>" crossorigin="anonymous"></script>
-    <script src="<%= script_name %>/js/application.js"></script>
-    <script src="<%= script_name %>/js/version.js"></script>
+    <script src="<%= script_name %>/js/application.js?v=<%= Flipper::VERSION %>"></script>
+    <script src="<%= script_name %>/js/version.js?v=<%= Flipper::VERSION %>"></script>
   </body>
 </html>

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -21,6 +21,8 @@
         <a href="https://www.flippercloud.io/docs/ui?utm_source=oss&utm_medium=ui&utm_campaign=docs">Docs</a> &bull;
         <a href="<%= script_name %>/settings">Settings</a> &bull;
         Version: <%= Flipper::VERSION %>
+        <a href="#" class="badge badge-warning ml-2 d-none" style="font-size:100%" id="new-version-badge" data-version="<%= Flipper::VERSION %>">
+        </a>
       </div>
 
       <nav aria-label="breadcrumb">
@@ -61,5 +63,6 @@
     <script src="<%= script_name + popper_js[:src] %>" integrity="<%= popper_js[:hash] %>" crossorigin="anonymous"></script>
     <script src="<%= script_name + bootstrap_js[:src] %>" integrity="<%= bootstrap_js[:hash] %>" crossorigin="anonymous"></script>
     <script src="<%= script_name %>/js/application.js"></script>
+    <script src="<%= script_name %>/js/version.js"></script>
   </body>
 </html>

--- a/lib/flipper/version.rb
+++ b/lib/flipper/version.rb
@@ -2,8 +2,10 @@ module Flipper
   VERSION = '1.1.2'.freeze
 
   REQUIRED_RUBY_VERSION = '2.6'.freeze
-
   NEXT_REQUIRED_RUBY_VERSION = '3.0'.freeze
+
+  REQUIRED_RAILS_VERSION = '5.2'.freeze
+  NEXT_REQUIRED_RAILS_VERSION = '6.1.0'.freeze
 
   def self.deprecated_ruby_version?
     Gem::Version.new(RUBY_VERSION) < Gem::Version.new(NEXT_REQUIRED_RUBY_VERSION)

--- a/lib/flipper/version.rb
+++ b/lib/flipper/version.rb
@@ -1,3 +1,11 @@
 module Flipper
   VERSION = '1.1.2'.freeze
+
+  REQUIRED_RUBY_VERSION = '2.6'.freeze
+
+  NEXT_REQUIRED_RUBY_VERSION = '3.0'.freeze
+
+  def self.deprecated_ruby_version?
+    Gem::Version.new(RUBY_VERSION) < Gem::Version.new(NEXT_REQUIRED_RUBY_VERSION)
+  end
 end


### PR DESCRIPTION
This PR adds badges to notify of new Flipper releases along with Ruby/Rails version deprecations (#776). Here is worst case scenario where a user has deprecated Ruby/Rails versions, and an old Flipper version.

<img width="614" alt="image" src="https://github.com/flippercloud/flipper/assets/173/76950ff1-0001-471c-a4e9-0b9bc6ec7c88">