### PR TITLE
Fix: Define default_strict_value before it's called

### DIFF
--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -1,5 +1,19 @@
 module Flipper
   class Engine < Rails::Engine
+    def self.default_strict_value
+      value = ENV["FLIPPER_STRICT"]
+      if value.in?(["warn", "raise", "noop"])
+        value.to_sym
+      elsif value
+        Typecast.to_boolean(value) ? :raise : false
+      elsif Rails.env.production?
+        false
+      else
+        # Warn for now. Future versions will default to :raise in development and test
+        :warn
+      end
+    end
+
     paths["config/routes.rb"] = ["lib/flipper/cloud/routes.rb"]
 
     config.before_configuration do
@@ -68,20 +82,6 @@ module Flipper
 
     def cloud?
       !!ENV["FLIPPER_CLOUD_TOKEN"]
-    end
-
-    def self.default_strict_value
-      value = ENV["FLIPPER_STRICT"]
-      if value.in?(["warn", "raise", "noop"])
-        value.to_sym
-      elsif value
-        Typecast.to_boolean(value) ? :raise : false
-      elsif Rails.env.production?
-        false
-      else
-        # Warn for now. Future versions will default to :raise in development and test
-        :warn
-      end
     end
 
     def self.deprecated_rails_version?


### PR DESCRIPTION
Flipper fails to load due to missing method `default_strict_value`
```
/Users/user/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.2/lib/rails/railtie.rb:228:in `method_missing': undefined local variable or method `default_strict_value' for Flipper::Engine:Class (NameError)
        from /Users/user/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/flipper-1.1.2/lib/flipper/engine.rb:13:in `block in <class:Engine>'
```

Moving the method to the top of the class (before it's used) solves the problem.

Tested on a brand new rails project
Rails 7.1.2
Ruby 3.2.2

Gemfile:
```
gem "flipper", "~> 1.1", require: false
gem "flipper-redis", require: false
gem "flipper-ui", require: false
```

flipper initializer:
```
require "flipper"
require "flipper/adapters/redis"
require "flipper/adapters/instrumented"

Flipper.configure do |config|
  config.default do
    redis_config = Rails.application.config_for("redis-pool").symbolize_keys
    connection = Redis.new(redis_config)
    adapter = Flipper::Adapters::Redis.new(connection)
    instrumented = Flipper::Adapters::Instrumented.new(
      adapter, instrumenter: ActiveSupport::Notifications
    )

    Flipper.new(instrumented, instrumenter: ActiveSupport::Notifications)
  end
end
```