### PR TITLE
Standardize Headers

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -21,6 +21,7 @@ guard 'rspec', rspec_options do
   watch('lib/flipper/api/middleware.rb') { 'spec/flipper/api_spec.rb' }
   watch(/shared_adapter_specs\.rb$/) { 'spec' }
   watch('spec/helper.rb') { 'spec' }
+  watch('lib/flipper/adapters/http/client.rb') { 'spec/flipper/adapters/http_spec.rb' }
 
   # To run all specs on every change... (useful with focus and fit)
   # watch(%r{.*}) { 'spec' }

--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -24,7 +24,8 @@ module Flipper
 
         attr_reader :uri, :headers
         attr_reader :basic_auth_username, :basic_auth_password
-        attr_reader :read_timeout, :open_timeout, :write_timeout, :max_retries, :debug_output
+        attr_reader :read_timeout, :open_timeout, :write_timeout
+        attr_reader :max_retries, :debug_output
 
         def initialize(options = {})
           @uri = URI(options.fetch(:url))

--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -15,10 +15,10 @@ module Flipper
         HTTPS_SCHEME = "https".freeze
 
         CLIENT_FRAMEWORKS = {
-          rails: -> { Rails.version if defined?(Rails) },
-          sinatra: -> { Sinatra::VERSION if defined?(Sinatra) },
-          hanami: -> { Hanami::VERSION if defined?(Hanami) },
-          sidekiq: -> { Sidekiq::VERSION if defined?(Sidekiq) },
+          rails:    -> { Rails.version if defined?(Rails) },
+          sinatra:  -> { Sinatra::VERSION if defined?(Sinatra) },
+          hanami:   -> { Hanami::VERSION if defined?(Hanami) },
+          sidekiq:  -> { Sidekiq::VERSION if defined?(Sidekiq) },
           good_job: -> { GoodJob::VERSION if defined?(GoodJob) },
         }
 
@@ -45,7 +45,7 @@ module Flipper
         end
 
         def add_header(key, value)
-          key = key.to_s.downcase.freeze
+          key = key.to_s.downcase.gsub('_'.freeze, '-'.freeze).freeze
           @headers[key] = value
         end
 

--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -109,7 +109,7 @@ module Flipper
           request.initialize_http_header(request_headers)
 
           client_frameworks.each do |framework, version|
-            request.add_field("Client-Framework", [framework, version].join("="))
+            request.add_field("client-framework", [framework, version].join("="))
           end
 
           request.body = body if body

--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -7,9 +7,9 @@ module Flipper
     class Http
       class Client
         DEFAULT_HEADERS = {
-          'Content-Type' => 'application/json',
-          'Accept' => 'application/json',
-          'User-Agent' => "Flipper HTTP Adapter v#{VERSION}",
+          'content-type' => 'application/json',
+          'accept' => 'application/json',
+          'user-agent' => "Flipper HTTP Adapter v#{VERSION}",
         }.freeze
 
         HTTPS_SCHEME = "https".freeze
@@ -18,6 +18,8 @@ module Flipper
           rails: -> { Rails.version if defined?(Rails) },
           sinatra: -> { Sinatra::VERSION if defined?(Sinatra) },
           hanami: -> { Hanami::VERSION if defined?(Hanami) },
+          sidekiq: -> { Sidekiq::VERSION if defined?(Sidekiq) },
+          good_job: -> { GoodJob::VERSION if defined?(GoodJob) },
         }
 
         attr_reader :uri, :headers
@@ -26,7 +28,6 @@ module Flipper
 
         def initialize(options = {})
           @uri = URI(options.fetch(:url))
-          @headers = DEFAULT_HEADERS.merge(options[:headers] || {})
           @basic_auth_username = options[:basic_auth_username]
           @basic_auth_password = options[:basic_auth_password]
           @read_timeout = options[:read_timeout]
@@ -34,9 +35,16 @@ module Flipper
           @write_timeout = options[:write_timeout]
           @max_retries = options.key?(:max_retries) ? options[:max_retries] : 0
           @debug_output = options[:debug_output]
+
+          @headers = {}
+          DEFAULT_HEADERS.each { |key, value| add_header key, value }
+          if options[:headers]
+            options[:headers].each { |key, value| add_header key, value }
+          end
         end
 
         def add_header(key, value)
+          key = key.to_s.downcase.freeze
           @headers[key] = value
         end
 
@@ -87,13 +95,13 @@ module Flipper
 
         def build_request(http_method, uri, headers, options)
           request_headers = {
-            client_language: "ruby",
-            client_language_version: "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
-            client_platform: RUBY_PLATFORM,
-            client_engine: defined?(RUBY_ENGINE) ? RUBY_ENGINE : "",
-            client_pid: Process.pid.to_s,
-            client_thread: Thread.current.object_id.to_s,
-            client_hostname: Socket.gethostname,
+            'client-language' => "ruby",
+            'client-language-version' => "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
+            'client-platform' => RUBY_PLATFORM,
+            'client-engine' => defined?(RUBY_ENGINE) ? RUBY_ENGINE : "",
+            'client-pid' => Process.pid.to_s,
+            'client-thread' => Thread.current.object_id.to_s,
+            'client-hostname' => Socket.gethostname,
           }.merge(headers)
 
           body = options[:body]

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -163,8 +163,8 @@ module Flipper
           max_retries: 0, # we'll handle retries ourselves
           debug_output: @debug_output,
           headers: {
-            flipper_cloud_token: @token,
-            accept_encoding: "gzip",
+            "flipper-cloud-token" => @token,
+            "accept-encoding" => "gzip",
           },
         })
       end

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -187,6 +187,11 @@ module Flipper
       def setup_http(options)
         set_option :url, options, default: DEFAULT_URL
         set_option :debug_output, options, from_env: false
+
+        if @debug_output.nil? && Flipper::Typecast.to_boolean(ENV["FLIPPER_CLOUD_DEBUG_OUTPUT_STDOUT"])
+          @debug_output = STDOUT
+        end
+
         set_option :read_timeout, options, default: 5, typecast: :float, minimum: 0.1
         set_option :open_timeout, options, default: 2, typecast: :float, minimum: 0.1
         set_option :write_timeout, options, default: 5, typecast: :float, minimum: 0.1

--- a/lib/flipper/cloud/middleware.rb
+++ b/lib/flipper/cloud/middleware.rb
@@ -41,12 +41,12 @@ module Flipper
                 })
               rescue Flipper::Adapters::Http::Error => error
                 status = error.response.code.to_i == 402 ? 402 : 500
-                headers["Flipper-Cloud-Response-Error-Class"] = error.class.name
-                headers["Flipper-Cloud-Response-Error-Message"] = error.message
+                headers["flipper-cloud-response-error-class"] = error.class.name
+                headers["flipper-cloud-response-error-message"] = error.message
               rescue => error
                 status = 500
-                headers["Flipper-Cloud-Response-Error-Class"] = error.class.name
-                headers["Flipper-Cloud-Response-Error-Message"] = error.message
+                headers["flipper-cloud-response-error-class"] = error.class.name
+                headers["flipper-cloud-response-error-message"] = error.message
               end
             end
           rescue MessageVerifier::InvalidSignature

--- a/lib/flipper/cloud/telemetry/submitter.rb
+++ b/lib/flipper/cloud/telemetry/submitter.rb
@@ -78,8 +78,8 @@ module Flipper
 
         def submit(body)
           client = @cloud_configuration.http_client
-          client.add_header :schema_version, SCHEMA_VERSION
-          client.add_header :content_encoding, GZIP_ENCODING
+          client.add_header "schema-version", SCHEMA_VERSION
+          client.add_header "content-encoding", GZIP_ENCODING
 
           response = client.post PATH, body
           code = response.code.to_i

--- a/spec/flipper/adapters/http/client_spec.rb
+++ b/spec/flipper/adapters/http/client_spec.rb
@@ -1,0 +1,61 @@
+require "flipper/adapters/http/client"
+
+RSpec.describe Flipper::Adapters::Http::Client do
+  describe "#initialize" do
+    it "requires url" do
+      expect { described_class.new }.to raise_error(KeyError, "key not found: :url")
+    end
+
+    it "sets default headers" do
+      client = described_class.new(url: "http://example.com")
+      expect(client.headers).to eq({
+        'content-type' => 'application/json',
+        'accept' => 'application/json',
+        'user-agent' => "Flipper HTTP Adapter v#{Flipper::VERSION}",
+      })
+    end
+
+    it "adds custom headers" do
+      client = described_class.new(url: "http://example.com", headers: {'custom-header' => 'value'})
+      expect(client.headers).to include('custom-header' => 'value')
+    end
+
+    it "overrides default headers with custom headers" do
+      client = described_class.new(url: "http://example.com", headers: {'content-type' => 'text/plain'})
+      expect(client.headers['content-type']).to eq('text/plain')
+    end
+  end
+
+  describe "#add_header" do
+    it "can add string header" do
+      client = described_class.new(url: "http://example.com")
+      client.add_header("key", "value")
+      expect(client.headers.fetch("key")).to eq("value")
+    end
+
+    it "standardizes key to lowercase" do
+      client = described_class.new(url: "http://example.com")
+      client.add_header("Content-Type", "value")
+      expect(client.headers.fetch("content-type")).to eq("value")
+    end
+
+    it "standardizes key to dashes" do
+      client = described_class.new(url: "http://example.com")
+      client.add_header(:content_type, "value")
+      expect(client.headers.fetch("content-type")).to eq("value")
+    end
+
+    it "can add symbol header" do
+      client = described_class.new(url: "http://example.com")
+      client.add_header(:key, "value")
+      expect(client.headers.fetch("key")).to eq("value")
+    end
+
+    it "overrides existing header" do
+      client = described_class.new(url: "http://example.com")
+      client.add_header("key", "value 1")
+      client.add_header("key", "value 2")
+      expect(client.headers.fetch("key")).to eq("value 2")
+    end
+  end
+end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -103,9 +103,17 @@ RSpec.describe Flipper::Adapters::Http do
     stub_const("Rails", double(version: "7.1.0"))
     stub_const("Sinatra::VERSION", "3.1.0")
     stub_const("Hanami::VERSION", "0.7.2")
+    stub_const("GoodJob::VERSION", "3.21.5")
+    stub_const("Sidekiq::VERSION", "7.2.0")
 
     headers = {
-      "client-framework" => ["rails=7.1.0", "sinatra=3.1.0", "hanami=0.7.2"]
+      "client-framework" => [
+        "rails=7.1.0",
+        "sinatra=3.1.0",
+        "hanami=0.7.2",
+        "good_job=3.21.5",
+        "sidekiq=7.2.0",
+      ]
     }
 
     stub_request(:get, "http://app.com/flipper/features/feature_panel")

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Flipper::Adapters::Http do
 
   {
     basic: default_options.dup,
-    gzip: default_options.dup.merge(headers: { accept_encoding: 'gzip' }),
+    gzip: default_options.dup.merge(headers: { 'accept-encoding': 'gzip' }),
   }.each do |name, options|
     context "adapter (#{name} #{options.inspect})" do
       subject do
@@ -87,9 +87,9 @@ RSpec.describe Flipper::Adapters::Http do
 
   it "sends default headers" do
     headers = {
-      'Accept' => 'application/json',
-      'Content-Type' => 'application/json',
-      'User-Agent' => "Flipper HTTP Adapter v#{Flipper::VERSION}",
+      'accept' => 'application/json',
+      'content-type' => 'application/json',
+      'user-agent' => "Flipper HTTP Adapter v#{Flipper::VERSION}",
     }
     stub_request(:get, "http://app.com/flipper/features/feature_panel")
       .with(headers: headers)
@@ -105,7 +105,7 @@ RSpec.describe Flipper::Adapters::Http do
     stub_const("Hanami::VERSION", "0.7.2")
 
     headers = {
-      "Client-Framework" => ["rails=7.1.0", "sinatra=3.1.0", "hanami=0.7.2"]
+      "client-framework" => ["rails=7.1.0", "sinatra=3.1.0", "hanami=0.7.2"]
     }
 
     stub_request(:get, "http://app.com/flipper/features/feature_panel")
@@ -121,7 +121,7 @@ RSpec.describe Flipper::Adapters::Http do
     stub_const("Sinatra::VERSION", "3.1.0")
 
     headers = {
-      "Client-Framework" => ["rails=7.1.0", "sinatra=3.1.0"]
+      "client-framework" => ["rails=7.1.0", "sinatra=3.1.0"]
     }
 
     stub_request(:get, "http://app.com/flipper/features/feature_panel")
@@ -289,7 +289,7 @@ RSpec.describe Flipper::Adapters::Http do
     let(:options) do
       {
         url: 'http://app.com/mount-point',
-        headers: { 'X-Custom-Header' => 'foo' },
+        headers: { 'x-custom-header' => 'foo' },
         basic_auth_username: 'username',
         basic_auth_password: 'password',
         read_timeout: 100,
@@ -310,7 +310,7 @@ RSpec.describe Flipper::Adapters::Http do
       subject.get(feature)
       expect(
         a_request(:get, 'http://app.com/mount-point/features/feature_panel')
-        .with(headers: { 'X-Custom-Header' => 'foo' })
+        .with(headers: { 'x-custom-header' => 'foo' })
       ).to have_been_made.once
     end
 

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -233,9 +233,9 @@ RSpec.describe Flipper::Cloud::Configuration do
     stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
       with({
         headers: {
-          'Flipper-Cloud-Token'=>'asdf',
+          'flipper-cloud-token'=>'asdf',
         },
-      }).to_return(status: 200, body: body, headers: {})
+      }).to_return(status: 200, body: body)
     instance = described_class.new(required_options)
     instance.sync
 

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -86,6 +86,13 @@ RSpec.describe Flipper::Cloud::Configuration do
     expect(instance.debug_output).to eq(STDOUT)
   end
 
+  it "defaults debug_output to STDOUT if FLIPPER_CLOUD_DEBUG_OUTPUT_STDOUT set to true" do
+    with_env "FLIPPER_CLOUD_DEBUG_OUTPUT_STDOUT" => "true" do
+      instance = described_class.new(required_options)
+    expect(instance.debug_output).to eq(STDOUT)
+    end
+  end
+
   it "defaults adapter block" do
     # The initial sync of http to local invokes this web request.
     stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")

--- a/spec/flipper/cloud/dsl_spec.rb
+++ b/spec/flipper/cloud/dsl_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Flipper::Cloud::DSL do
     stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
       with({
         headers: {
-          'Flipper-Cloud-Token'=>'asdf',
+          'flipper-cloud-token'=>'asdf',
         },
       }).to_return(status: 200, body: '{"features": {}}', headers: {})
     cloud_configuration = Flipper::Cloud::Configuration.new({
@@ -65,11 +65,11 @@ RSpec.describe Flipper::Cloud::DSL do
 
     it "sends writes to cloud and local" do
       add_stub = stub_request(:post, "https://www.flippercloud.io/adapter/features").
-        with({headers: {'Flipper-Cloud-Token'=>'asdf'}}).
-        to_return(status: 200, body: '{}', headers: {})
+        with({headers: {'flipper-cloud-token'=>'asdf'}}).
+        to_return(status: 200, body: '{}')
       enable_stub = stub_request(:post, "https://www.flippercloud.io/adapter/features/foo/boolean").
-        with(headers: {'Flipper-Cloud-Token'=>'asdf'}).
-        to_return(status: 200, body: '{}', headers: {})
+        with(headers: {'flipper-cloud-token'=>'asdf'}).
+        to_return(status: 200, body: '{}')
 
       subject.enable(:foo)
 

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe Flipper::Cloud::Middleware do
       post '/', request_body, env
 
       expect(last_response.status).to eq(402)
-      expect(last_response.headers["Flipper-Cloud-Response-Error-Class"]).to eq("Flipper::Adapters::Http::Error")
-      expect(last_response.headers["Flipper-Cloud-Response-Error-Message"]).to include("Failed with status: 402")
+      expect(last_response.headers["flipper-cloud-response-error-class"]).to eq("Flipper::Adapters::Http::Error")
+      expect(last_response.headers["flipper-cloud-response-error-message"]).to include("Failed with status: 402")
       expect(stub).to have_been_requested
     end
   end
@@ -124,8 +124,8 @@ RSpec.describe Flipper::Cloud::Middleware do
       post '/', request_body, env
 
       expect(last_response.status).to eq(500)
-      expect(last_response.headers["Flipper-Cloud-Response-Error-Class"]).to eq("Flipper::Adapters::Http::Error")
-      expect(last_response.headers["Flipper-Cloud-Response-Error-Message"]).to include("Failed with status: 503")
+      expect(last_response.headers["flipper-cloud-response-error-class"]).to eq("Flipper::Adapters::Http::Error")
+      expect(last_response.headers["flipper-cloud-response-error-message"]).to include("Failed with status: 503")
       expect(stub).to have_been_requested
     end
   end
@@ -147,8 +147,8 @@ RSpec.describe Flipper::Cloud::Middleware do
       post '/', request_body, env
 
       expect(last_response.status).to eq(500)
-      expect(last_response.headers["Flipper-Cloud-Response-Error-Class"]).to eq("Net::OpenTimeout")
-      expect(last_response.headers["Flipper-Cloud-Response-Error-Message"]).to eq("execution expired")
+      expect(last_response.headers["flipper-cloud-response-error-class"]).to eq("Net::OpenTimeout")
+      expect(last_response.headers["flipper-cloud-response-error-message"]).to eq("execution expired")
       expect(stub).to have_been_requested
     end
   end
@@ -277,13 +277,13 @@ RSpec.describe Flipper::Cloud::Middleware do
     stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
       with({
         headers: {
-          'Flipper-Cloud-Token' => token,
+          'flipper-cloud-token' => token,
         },
       })
     if status == :timeout
       stub.to_timeout
     else
-      stub.to_return(status: status, body: response_body, headers: {})
+      stub.to_return(status: status, body: response_body)
     end
   end
 end

--- a/spec/flipper/cloud/telemetry_spec.rb
+++ b/spec/flipper/cloud/telemetry_spec.rb
@@ -4,7 +4,7 @@ require 'flipper/cloud/configuration'
 RSpec.describe Flipper::Cloud::Telemetry do
   it "phones home and does not update telemetry interval if missing" do
     stub = stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
-      to_return(status: 200, body: "{}", headers: {})
+      to_return(status: 200, body: "{}")
 
     cloud_configuration = Flipper::Cloud::Configuration.new(token: "test")
 

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Flipper::Cloud do
       expect(client.uri.scheme).to eq('https')
       expect(client.uri.host).to eq('www.flippercloud.io')
       expect(client.uri.path).to eq('/adapter')
-      expect(client.headers[:flipper_cloud_token]).to eq(token)
+      expect(client.headers["flipper-cloud-token"]).to eq(token)
       expect(@instance.instrumenter).to be(Flipper::Instrumenters::Noop)
     end
   end
@@ -104,7 +104,7 @@ RSpec.describe Flipper::Cloud do
 
   it 'can import' do
     stub_request(:post, /www\.flippercloud\.io\/adapter\/features.*/).
-      with(headers: {'Flipper-Cloud-Token'=>'asdf'}).to_return(status: 200, body: "{}", headers: {})
+      with(headers: {'flipper-cloud-token'=>'asdf'}).to_return(status: 200, body: "{}", headers: {})
 
     flipper = Flipper.new(Flipper::Adapters::Memory.new)
 
@@ -130,7 +130,7 @@ RSpec.describe Flipper::Cloud do
 
   it 'raises error for failure while importing' do
     stub_request(:post, /www\.flippercloud\.io\/adapter\/features.*/).
-      with(headers: {'Flipper-Cloud-Token'=>'asdf'}).to_return(status: 500, body: "{}")
+      with(headers: {'flipper-cloud-token'=>'asdf'}).to_return(status: 500, body: "{}")
 
     flipper = Flipper.new(Flipper::Adapters::Memory.new)
 
@@ -155,7 +155,7 @@ RSpec.describe Flipper::Cloud do
 
   it 'raises error for timeout while importing' do
     stub_request(:post, /www\.flippercloud\.io\/adapter\/features.*/).
-      with(headers: {'Flipper-Cloud-Token'=>'asdf'}).to_timeout
+      with(headers: {'flipper-cloud-token'=>'asdf'}).to_timeout
 
     flipper = Flipper.new(Flipper::Adapters::Memory.new)
 

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Flipper::Engine do
         application.initialize!
 
         stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").with({
-          headers: { "Flipper-Cloud-Token" => ENV["FLIPPER_CLOUD_TOKEN"] },
+          headers: { "flipper-cloud-token" => ENV["FLIPPER_CLOUD_TOKEN"] },
         }).to_return(status: 200, body: JSON.generate({ features: {} }), headers: {})
 
         post "/_flipper", request_body, { "HTTP_FLIPPER_CLOUD_SIGNATURE" => signature_header_value }

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search')
+        expect(last_response.headers['location']).to eq('/features/search')
       end
 
       context "when feature name contains space" do
@@ -84,7 +84,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
         it "redirects back to feature" do
           expect(last_response.status).to be(302)
-          expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+          expect(last_response.headers['location']).to eq('/features/sp%20ace')
         end
       end
 
@@ -114,7 +114,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/actors?error=%22%22%20is%20not%20a%20valid%20actor%20value.')
+            expect(last_response.headers['location']).to eq('/features/search/actors?error=%22%22%20is%20not%20a%20valid%20actor%20value.')
           end
         end
 
@@ -123,7 +123,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/actors?error=%22%22%20is%20not%20a%20valid%20actor%20value.')
+            expect(last_response.headers['location']).to eq('/features/search/actors?error=%22%22%20is%20not%20a%20valid%20actor%20value.')
           end
         end
       end
@@ -175,7 +175,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search')
+        expect(last_response.headers['location']).to eq('/features/search')
       end
 
       context 'value contains whitespace' do

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search')
+        expect(last_response.headers['location']).to eq('/features/search')
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+        expect(last_response.headers['location']).to eq('/features/sp%20ace')
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search')
+        expect(last_response.headers['location']).to eq('/features/search')
       end
     end
   end

--- a/spec/flipper/ui/actions/export_spec.rb
+++ b/spec/flipper/ui/actions/export_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe Flipper::UI::Actions::Features do
     end
 
     it 'sets content disposition' do
-      expect(last_response.headers['Content-Disposition']).to match(/Attachment;filename=flipper_memory_[0-9]*\.json/)
+      expect(last_response.headers['content-disposition']).to match(/Attachment;filename=flipper_memory_[0-9]*\.json/)
     end
 
     it 'renders json' do
       data = JSON.parse(last_response.body)
-      expect(last_response.headers['Content-Type']).to eq('application/json')
+      expect(last_response.headers['content-type']).to eq('application/json')
       expect(data['version']).to eq(1)
       expect(data['features']).to eq({
         "analytics" => {"boolean"=>nil, "expression"=>{"Equal"=>[{"Property"=>["plan"]}, "basic"]}, "groups"=>[], "actors"=>[], "percentage_of_actors"=>nil, "percentage_of_time"=>nil},

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Flipper::UI::Actions::Feature do
 
     it 'redirects to features' do
       expect(last_response.status).to be(302)
-      expect(last_response.headers['Location']).to eq('/features')
+      expect(last_response.headers['location']).to eq('/features')
     end
 
     context "with space in feature name" do
@@ -41,7 +41,7 @@ RSpec.describe Flipper::UI::Actions::Feature do
 
       it 'redirects to features' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features')
+        expect(last_response.headers['location']).to eq('/features')
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Flipper::UI::Actions::Feature do
 
     it 'redirects to features' do
       expect(last_response.status).to be(302)
-      expect(last_response.headers['Location']).to eq('/features')
+      expect(last_response.headers['location']).to eq('/features')
     end
   end
 

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Flipper::UI::Actions::Features do
 
       it 'redirects to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/notifications_next')
+        expect(last_response.headers['location']).to eq('/features/notifications_next')
       end
 
       context 'feature name has whitespace at beginning and end' do
@@ -124,7 +124,7 @@ RSpec.describe Flipper::UI::Actions::Features do
 
         it 'redirects to feature' do
           expect(last_response.status).to be(302)
-          expect(last_response.headers['Location']).to eq('/features/notifications%20next')
+          expect(last_response.headers['location']).to eq('/features/notifications%20next')
         end
       end
 
@@ -138,7 +138,7 @@ RSpec.describe Flipper::UI::Actions::Features do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/new?error=%22%22%20is%20not%20a%20valid%20feature%20name.')
+            expect(last_response.headers['location']).to eq('/features/new?error=%22%22%20is%20not%20a%20valid%20feature%20name.')
           end
         end
 
@@ -151,7 +151,7 @@ RSpec.describe Flipper::UI::Actions::Features do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/new?error=%22%22%20is%20not%20a%20valid%20feature%20name.')
+            expect(last_response.headers['location']).to eq('/features/new?error=%22%22%20is%20not%20a%20valid%20feature%20name.')
           end
         end
       end

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search')
+        expect(last_response.headers['location']).to eq('/features/search')
       end
 
       context 'feature name contains space' do
@@ -71,7 +71,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
         it 'redirects back to feature' do
           expect(last_response.status).to be(302)
-          expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+          expect(last_response.headers['location']).to eq('/features/sp%20ace')
         end
       end
 
@@ -89,7 +89,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The%20group%20named%20%22not_here%22%20has%20not%20been%20registered.')
+            expect(last_response.headers['location']).to eq('/features/search/groups?error=The%20group%20named%20%22not_here%22%20has%20not%20been%20registered.')
           end
         end
 
@@ -98,7 +98,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The%20group%20named%20%22%22%20has%20not%20been%20registered.')
+            expect(last_response.headers['location']).to eq('/features/search/groups?error=The%20group%20named%20%22%22%20has%20not%20been%20registered.')
           end
         end
 
@@ -107,7 +107,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The%20group%20named%20%22%22%20has%20not%20been%20registered.')
+            expect(last_response.headers['location']).to eq('/features/search/groups?error=The%20group%20named%20%22%22%20has%20not%20been%20registered.')
           end
         end
       end
@@ -129,7 +129,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search')
+        expect(last_response.headers['location']).to eq('/features/search')
       end
 
       context 'group name contains whitespace' do

--- a/spec/flipper/ui/actions/home_spec.rb
+++ b/spec/flipper/ui/actions/home_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Flipper::UI::Actions::Home do
 
     it 'responds with redirect' do
       expect(last_response.status).to be(302)
-      expect(last_response.headers['Location']).to eq('/features')
+      expect(last_response.headers['location']).to eq('/features')
     end
   end
 end

--- a/spec/flipper/ui/actions/import_spec.rb
+++ b/spec/flipper/ui/actions/import_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Flipper::UI::Actions::Import do
 
     it 'responds with redirect to settings' do
       expect(last_response.status).to be(302)
-      expect(last_response.headers['Location']).to eq('/features')
+      expect(last_response.headers['location']).to eq('/features')
     end
   end
 end

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search')
+        expect(last_response.headers['location']).to eq('/features/search')
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+        expect(last_response.headers['location']).to eq('/features/sp%20ace')
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search?error=Invalid%20percentage%20of%20actors%20value:%20value%20must%20be%20a%20positive%20number%20less%20than%20or%20equal%20to%20100,%20but%20was%20555')
+        expect(last_response.headers['location']).to eq('/features/search?error=Invalid%20percentage%20of%20actors%20value:%20value%20must%20be%20a%20positive%20number%20less%20than%20or%20equal%20to%20100,%20but%20was%20555')
       end
     end
   end

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search')
+        expect(last_response.headers['location']).to eq('/features/search')
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+        expect(last_response.headers['location']).to eq('/features/sp%20ace')
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search?error=Invalid%20percentage%20of%20time%20value:%20value%20must%20be%20a%20positive%20number%20less%20than%20or%20equal%20to%20100,%20but%20was%20555')
+        expect(last_response.headers['location']).to eq('/features/search?error=Invalid%20percentage%20of%20time%20value:%20value%20must%20be%20a%20positive%20number%20less%20than%20or%20equal%20to%20100,%20but%20was%20555')
       end
     end
   end

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Flipper::UI do
          { 'value' => 'User;6', 'operation' => 'enable', 'authenticity_token' => token },
          'rack.session' => session
     expect(last_response.status).to be(302)
-    expect(last_response.headers['Location']).to eq('/features/refactor-images')
+    expect(last_response.headers['location']).to eq('/features/refactor-images')
   end
 
   describe 'configure' do

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Flipper do
       stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
         with({
           headers: {
-            'Flipper-Cloud-Token'=>'asdf',
+            'flipper-cloud-token'=>'asdf',
           },
         }).to_return(status: 200, body: '{"features": {}}', headers: {})
       cloud_configuration = Flipper::Cloud::Configuration.new({


### PR DESCRIPTION
I get confused about headers in ruby all the time: is it suppose to be capitalized, lower case, a symbol or a string, dashes, etc...? 

This standardizes on lower case with dash like rack 3. I also added good job and sidekiq to the detected frameworks in cloud and a way to print http debug_output to stdout via env var (FLIPPER_CLOUD_DEBUG_OUTPUT_STDOUT=true, easier to config than manual).

