### PR TITLE
Fix for setting `config.flipper.strict = true`

### DIFF
--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -43,10 +43,6 @@ module Flipper
       require 'flipper/cloud' if cloud?
 
       Flipper.configure do |config|
-        if app.config.flipper.strict
-          config.use Flipper::Adapters::Strict, app.config.flipper.strict
-        end
-
         config.default do
           if cloud?
             Flipper::Cloud.new(
@@ -65,6 +61,16 @@ module Flipper
 
       if flipper.log && flipper.instrumenter == ActiveSupport::Notifications
         require "flipper/instrumentation/log_subscriber"
+      end
+    end
+
+    initializer "flipper.strict", after: :load_config_initializers do |app|
+      flipper = app.config.flipper
+
+      if flipper.strict
+        Flipper.configure do |config|
+          config.use Flipper::Adapters::Strict, flipper.strict
+        end
       end
     end
 

--- a/spec/flipper/adapter_builder_spec.rb
+++ b/spec/flipper/adapter_builder_spec.rb
@@ -38,10 +38,9 @@ RSpec.describe Flipper::AdapterBuilder do
       strict_adapter = memoizable_adapter.adapter
       memory_adapter = strict_adapter.adapter
 
-
       expect(memoizable_adapter).to be_instance_of(Flipper::Adapters::Memoizable)
       expect(strict_adapter).to be_instance_of(Flipper::Adapters::Strict)
-      expect(strict_adapter.handler).to be(Flipper::Adapters::Strict::HANDLERS.fetch(:warn))
+      expect(strict_adapter.handler).to be(:warn)
       expect(memory_adapter).to be_instance_of(Flipper::Adapters::Memory)
     end
 

--- a/spec/flipper/adapters/strict_spec.rb
+++ b/spec/flipper/adapters/strict_spec.rb
@@ -6,18 +6,20 @@ RSpec.describe Flipper::Adapters::Strict do
     subject { described_class.new(Flipper::Adapters::Memory.new, :noop) }
   end
 
-  context "handler = :raise" do
-    subject { described_class.new(Flipper::Adapters::Memory.new, :raise) }
+  [true, :raise].each do |handler|
+    context "handler = #{handler}" do
+      subject { described_class.new(Flipper::Adapters::Memory.new, handler) }
 
-    context "#get" do
-      it "raises an error for unknown feature" do
-        expect { subject.get(feature) }.to raise_error(Flipper::Adapters::Strict::NotFound)
+      context "#get" do
+        it "raises an error for unknown feature" do
+          expect { subject.get(feature) }.to raise_error(Flipper::Adapters::Strict::NotFound)
+        end
       end
-    end
 
-    context "#get_multi" do
-      it "raises an error for unknown feature" do
-        expect { subject.get_multi([feature]) }.to raise_error(Flipper::Adapters::Strict::NotFound)
+      context "#get_multi" do
+        it "raises an error for unknown feature" do
+          expect { subject.get_multi([feature]) }.to raise_error(Flipper::Adapters::Strict::NotFound)
+        end
       end
     end
   end


### PR DESCRIPTION
- Fixes #792 where setting `config.flipper.strict = true` would raise an error
- Refactors Strict adapter to just use a case statement instead of Hash of procs
- Wait to initialize the Strict adapter after `config/initializers` so it respects values set there
