### PR TITLE
Add Ruby 3.3 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         rails: ['5.2', '6.0.0', '6.1.0', '7.0.0', '7.1.0']
         exclude:
           - ruby: "2.6"
@@ -47,6 +47,12 @@ jobs:
           - ruby: "3.2"
             rails: "6.0.0"
           - ruby: "3.2"
+            rails: "6.1.0"
+          - ruby: "3.3"
+            rails: "5.2"
+          - ruby: "3.3"
+            rails: "6.0.0"
+          - ruby: "3.3"
             rails: "6.1.0"
     env:
       SQLITE3_VERSION: 1.4.1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         rails: ['5.2', '6.0.0', '6.1.0', '7.0.0', '7.1.0']
         exclude:
           - ruby: "2.6"
@@ -36,6 +36,12 @@ jobs:
           - ruby: "3.2"
             rails: "6.0.0"
           - ruby: "3.2"
+            rails: "6.1.0"
+          - ruby: "3.3"
+            rails: "5.2"
+          - ruby: "3.3"
+            rails: "6.0.0"
+          - ruby: "3.3"
             rails: "6.1.0"
     env:
       SQLITE3_VERSION: 1.4.1

--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -6,7 +6,7 @@ plugin_files = []
 plugin_test_files = []
 
 Dir['flipper-*.gemspec'].map do |gemspec|
-  spec = eval(File.read(gemspec))
+  spec = Gem::Specification.load(gemspec)
   plugin_files << spec.files
   plugin_test_files << spec.files
 end


### PR DESCRIPTION
Only one small change needed for loading `*.gemspec` when building the gem, but previously released gems should work.