### PR TITLE
Add flipper/test_help to automatically configure Flipper in tests/specs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rspec', '~> 3.0'
 gem 'rack-test'
 gem 'rackup'
 gem 'sqlite3', "~> #{ENV['SQLITE3_VERSION'] || '1.4.1'}"
-gem 'rails', "~> #{ENV['RAILS_VERSION'] || '7.0.4'}"
+gem 'rails', "~> #{ENV['RAILS_VERSION'] || '7.1'}"
 gem 'minitest', '~> 5.18'
 gem 'minitest-documentation'
 gem 'webmock'
@@ -27,6 +27,8 @@ gem 'flamegraph'
 gem 'climate_control'
 gem 'mysql2'
 gem 'pg'
+gem 'cuprite'
+gem 'puma'
 
 group(:guard) do
   gem 'guard'

--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -24,7 +24,8 @@ module Flipper
         instrumenter: ENV.fetch('FLIPPER_INSTRUMENTER', 'ActiveSupport::Notifications').constantize,
         log: ENV.fetch('FLIPPER_LOG', 'true').casecmp('true').zero?,
         cloud_path: "_flipper",
-        strict: default_strict_value
+        strict: default_strict_value,
+        test_help: Flipper::Typecast.to_boolean(ENV["FLIPPER_TEST_HELP"] || Rails.env.test?),
       )
     end
 
@@ -84,6 +85,10 @@ module Flipper
           if: flipper.memoize.respond_to?(:call) ? flipper.memoize : nil
         }
       end
+    end
+
+    initializer "flipper.test" do |app|
+      require "flipper/test_help" if app.config.flipper.test_help
     end
 
     def cloud?

--- a/lib/flipper/test_help.rb
+++ b/lib/flipper/test_help.rb
@@ -1,0 +1,29 @@
+module Flipper
+  module TestHelp
+    extend self
+
+    def before_all
+      Flipper.configure do |config|
+        config.adapter { Flipper::Adapters::Memory.new }
+        config.default { Flipper.new(config.adapter) }
+      end
+    end
+
+    def before_each
+      Flipper.instance = nil # Reset previous flipper instance
+    end
+  end
+end
+
+if defined?(RSpec)
+  RSpec.configure do |config|
+    config.before(:all) { Flipper::TestHelp.before_all }
+    config.before(:each) { Flipper::TestHelp.before_each }
+  end
+elsif defined?(ActiveSupport::TestCase)
+  Flipper::TestHelp.before_all
+
+  ActiveSupport::TestCase.setup do
+    Flipper::TestHelp.before_each
+  end
+end

--- a/lib/flipper/test_help.rb
+++ b/lib/flipper/test_help.rb
@@ -1,7 +1,5 @@
 module Flipper
   module TestHelp
-    extend self
-
     def flipper_configure
       # Create a single shared memory adapter instance for each test
       @flipper_adapter = Flipper::Adapters::Memory.new

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -169,6 +169,46 @@ RSpec.describe Flipper::Engine do
         if: nil
       })
     end
+
+    context "test_help" do
+      it "is loaded if RAILS_ENV=test" do
+        Rails.env = "test"
+        allow(Flipper::Engine.instance).to receive(:require).and_call_original
+        expect(Flipper::Engine.instance).to receive(:require).with("flipper/test_help")
+        subject
+        expect(config.test_help).to eq(true)
+      end
+
+      it "is loaded if FLIPPER_TEST_HELP=true" do
+        ENV["FLIPPER_TEST_HELP"] = "true"
+        allow(Flipper::Engine.instance).to receive(:require).and_call_original
+        expect(Flipper::Engine.instance).to receive(:require).with("flipper/test_help")
+        subject
+        expect(config.test_help).to eq(true)
+      end
+
+      it "is loaded if config.flipper.test_help = true" do
+        initializer { config.test_help = true }
+        allow(Flipper::Engine.instance).to receive(:require).and_call_original
+        expect(Flipper::Engine.instance).to receive(:require).with("flipper/test_help")
+        subject
+      end
+
+      it "is not loaded if FLIPPER_TEST_HELP=false" do
+        ENV["FLIPPER_TEST_HELP"] = "false"
+        allow(Flipper::Engine.instance).to receive(:require).and_call_original
+        expect(Flipper::Engine.instance).to receive(:require).with("flipper/test_help").never
+        subject
+      end
+
+      it "is not loaded if config.flipper.test_help = false" do
+        Rails.env = "true"
+        initializer { config.test_help = false }
+        allow(Flipper::Engine.instance).to receive(:require).and_call_original
+        expect(Flipper::Engine.instance).to receive(:require).with("flipper/test_help").never
+        subject
+      end
+    end
   end
 
   context 'with cloud' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'flipper'
 require 'flipper/api'
 require 'flipper/spec/shared_adapter_specs'
 require 'flipper/ui'
+require 'flipper/test_help'
 
 Dir[FlipperRoot.join('spec/support/**/*.rb')].sort.each { |f| require f }
 

--- a/test_rails/system/test_help_test.rb
+++ b/test_rails/system/test_help_test.rb
@@ -1,4 +1,8 @@
 require_relative "../helper"
+
+# Not worth trying to test on old Rails versions
+return unless Rails::VERSION::MAJOR >= 7
+
 require "capybara/cuprite"
 require "flipper"
 require "flipper/test_help"

--- a/test_rails/system/test_help_test.rb
+++ b/test_rails/system/test_help_test.rb
@@ -23,13 +23,16 @@ TestApp.initialize!
 
 class FeaturesController < ActionController::Base
   def index
-    render inline: Flipper.enabled?(:test) ? "Enabled" : "Disabled"
+    render json: Flipper.enabled?(:test) ? "Enabled" : "Disabled"
   end
 end
 
 class TestHelpTest < ActionDispatch::SystemTestCase
   # Any driver that runs the app in a separate thread will test what we want here.
   driven_by :cuprite
+
+  # Ensure this test uses this app instance
+  setup { Rails.application = TestApp.instance }
 
   test "configures a shared adapter between tests and app" do
     Flipper.disable(:test)

--- a/test_rails/system/test_help_test.rb
+++ b/test_rails/system/test_help_test.rb
@@ -1,0 +1,39 @@
+require_relative "../helper"
+require "capybara/cuprite"
+require "flipper"
+require "flipper/test_help"
+
+require 'action_dispatch/system_testing/server'
+ActionDispatch::SystemTesting::Server.silence_puma = true
+
+class TestApp < Rails::Application
+  config.eager_load = false
+  config.logger = ActiveSupport::Logger.new(StringIO.new)
+  config.active_support.cache_format_version = 7.1
+  routes.append do
+    root to: "features#index"
+  end
+end
+
+TestApp.initialize!
+
+class FeaturesController < ActionController::Base
+  def index
+    render inline: Flipper.enabled?(:test) ? "Enabled" : "Disabled"
+  end
+end
+
+class TestHelpTest < ActionDispatch::SystemTestCase
+  # Any driver that runs the app in a separate thread will test what we want here.
+  driven_by :cuprite
+
+  test "configures a shared adapter between tests and app" do
+    Flipper.disable(:test)
+    visit "/"
+    assert_selector "*", text: "Disabled"
+
+    Flipper.enable(:test)
+    visit "/"
+    assert_selector "*", text: "Enabled"
+  end
+end

--- a/test_rails/system/test_help_test.rb
+++ b/test_rails/system/test_help_test.rb
@@ -11,9 +11,9 @@ require 'action_dispatch/system_testing/server'
 ActionDispatch::SystemTesting::Server.silence_puma = true
 
 class TestApp < Rails::Application
+  config.load_defaults "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
   config.eager_load = false
   config.logger = ActiveSupport::Logger.new(StringIO.new)
-  config.active_support.cache_format_version = 7.1
   routes.append do
     root to: "features#index"
   end


### PR DESCRIPTION
This adds `flipper/test_help` to automatically configure Rails/RSpec the way [we recommend in our testing docs](https://www.flippercloud.io/docs/testing).

Open questions:
1. Should `Flipper::Engine` automatically require this if `RAILS_ENV=test`? I think yes, but maybe we wait until 2.0 to do that?
2. As brought up in #807, what should the default value for `strict` be in test? Currently with `strict = :warn`, you also have to call `Flipper.add` for each feature. In theory, I like the explicitness of this. It will guard against typos in flag names, but also seems like busywork.  One option is to establish a pattern for defining features in an initializer, like this:

```ruby
# config/initializers/flipper.rb
module Feature
  Hubspot = Flipper.add(:hubspot)
  Seo = Flipper.add(:seo)
end

# app/jobs/hubspot_sync_job.rb
def perform(resource)
  return unless Feature::Hubspot.enabled?(resource)
end
```