### PR TITLE
CLI improvements to output and environment loading

### DIFF
--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://www.flippercloud.io/docs'
   gem.license       = 'MIT'
 
+  gem.bindir = "exe"
   gem.executables   = `git ls-files -- exe/*`.split("\n").map { |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n") - ignored_files + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n") - ignored_test_files

--- a/lib/flipper/cli.rb
+++ b/lib/flipper/cli.rb
@@ -169,7 +169,7 @@ module Flipper
           end.join(', ')
         end
 
-        colorize("%-#{padding}s" % feature.name, [:BOLD, :WHITE]) + " is #{summary}"
+        colorize("%-#{padding}s" % feature.key, [:BOLD, :WHITE]) + " is #{summary}"
       end
     end
 
@@ -180,7 +180,7 @@ module Flipper
       when :off
         "⦸ disabled"
       else
-        lines = ["#{colorize("◯ enabled", [:YELLOW])} for:\n"] + feature.enabled_gates.map do |gate|
+        lines = feature.enabled_gates.map do |gate|
           case gate.name
           when :actor
             [ pluralize(feature.actors_value.size, 'actor', 'actors') ] +
@@ -197,10 +197,12 @@ module Flipper
             "the expression: \n#{colorize(json, [:MAGENTA])}"
           end
         end
+
+        "#{colorize("◯ conditionally enabled", [:YELLOW])} for:\n" +
         indent(lines.flatten.join("\n"), 2)
       end
 
-      "#{colorize(feature.name, [:BOLD, :WHITE])} is #{summary}"
+      "#{colorize(feature.key, [:BOLD, :WHITE])} is #{summary}"
     end
 
     def pluralize(count, singular, plural)

--- a/lib/flipper/cli.rb
+++ b/lib/flipper/cli.rb
@@ -1,4 +1,3 @@
-require 'flipper'
 require 'optparse'
 
 module Flipper
@@ -126,6 +125,8 @@ module Flipper
 
     def load_environment!
       require File.expand_path(@require)
+      # Ensure all of flipper gets loaded if it hasn't already.
+      require 'flipper'
     rescue LoadError => e
       warn e.message
       exit 1

--- a/lib/flipper/cli.rb
+++ b/lib/flipper/cli.rb
@@ -121,6 +121,9 @@ module Flipper
           exit 1
         end
       end
+    rescue OptionParser::InvalidOption => e
+      warn e.message
+      exit 1
     end
 
     # Helper method to define a new command

--- a/spec/flipper/cli_spec.rb
+++ b/spec/flipper/cli_spec.rb
@@ -121,8 +121,11 @@ RSpec.describe Flipper::CLI do
     it { should have_attributes(status: 1, stderr: /Unknown command: nope/) }
   end
 
-  describe "show foo" do
+  describe "--nope" do
+    it { should have_attributes(status: 1, stderr: /invalid option: --nope/) }
+  end
 
+  describe "show foo" do
     context "boolean" do
       before { Flipper.enable :foo }
       it { should have_attributes(status: 0, stdout: /foo.*enabled/) }


### PR DESCRIPTION
1. Sets `bindir` in gemspec so ruby gems can find the `flipper` command
2. Delays requiring `flipper` so Rails integration gets properly loaded
3. Format and colorize output
4. Add support for expressions

<img width="477" alt="image" src="https://github.com/flippercloud/flipper/assets/173/657b049b-882e-4a00-b298-091a9cb38838">
