### PR TITLE
Use Sanitize on actor_names

### DIFF
--- a/examples/ui/basic.ru
+++ b/examples/ui/basic.ru
@@ -42,8 +42,8 @@ Flipper::UI.configure do |config|
 
   config.actor_names_source = lambda do |_keys|
     {
-      '1' => 'John',
-      '6' => 'Brandon',
+      '1' => '<a href="https://johnnunemaker.com">John</a>',
+      '6' => '<a href="https://opensoul.org">Brandon</a>',
     }
   end
 end

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -66,7 +66,7 @@
               <div class="col col-mr-auto pl-md-5">
                 <h6 class="m-0">
                   <% if Flipper::UI::Util.present?(@feature.actor_names[item]) %>
-                    <%= "#{@feature.actor_names[item]} (#{item})" %>
+                    <%== Sanitize.fragment("#{@feature.actor_names[item]} (#{item})", Sanitize::Config::BASIC) %>
                   <% else %>
                     <%= item %>
                   <% end %>

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -138,13 +138,34 @@ RSpec.describe Flipper::UI::Actions::Feature do
             }
           }
         end
-
-        get '/features/search'
       end
 
       it 'renders template with custom actor names' do
+        get '/features/search'
         expect(last_response.body).to include('Some Actor Name (some_actor_name)')
         expect(last_response.body).not_to include('Some Other Actor Name')
+      end
+
+      it 'allows basic html' do
+        Flipper::UI.configure do |config|
+          config.actor_names_source = lambda { |_keys|
+            { "some_actor_name" => '<a href="/users/some_actor_name">Some Actor Name</a>', }
+          }
+        end
+
+        get '/features/search'
+        expect(last_response.body).to include('<a href="/users/some_actor_name" rel="nofollow">Some Actor Name</a>')
+      end
+
+      it 'sanitizes dangerous markup' do
+        Flipper::UI.configure do |config|
+          config.actor_names_source = lambda { |_keys|
+            { "some_actor_name" => '<a href="javascript:alert(\'hello\')">Some Actor Name</a>', }
+          }
+        end
+
+        get '/features/search'
+        expect(last_response.body).not_to include('javascript:alert')
       end
     end
   end


### PR DESCRIPTION
Solves issue - https://github.com/flippercloud/flipper/issues/805

### Motivation & context

As pointed out in the issue, there is currently an inconsistency between how we treat on the UI some elements (eg. `Flipper::UI.configuration.banner_text`, `@feature.description`) and how we treat the `@feature.actor_names`.

The real world use case is making the actor names clickable as links to the resources that are the actors.

I've done the simplest possible change, not changing anything about the content itself.

### Changes

- apply `Sanitize.fragment` to the `"#{@feature.actor_names[item]} (#{item})"` on `feature.erb`

### Visual QA

<img width="645" alt="image" src="https://github.com/flippercloud/flipper/assets/12682792/3a4941b7-beb8-4e19-9de1-bb726bad4f1a">
