### PR TITLE
Quiet test output to make it easier to find errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,8 @@ end
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = %w(--color --format documentation)
+  t.rspec_opts = %w(--color)
+  t.verbose = false
 end
 
 namespace :spec do
@@ -41,7 +42,6 @@ end
 Rake::TestTask.new do |t|
   t.libs = %w(lib test)
   t.pattern = 'test/**/*_test.rb'
-  t.options = '--documentation'
   t.warning = false
 end
 

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'active_support/gem_version'
 require 'active_support/notifications'
 require 'active_support/log_subscriber'
 
@@ -74,8 +75,7 @@ module Flipper
       private
 
       # Rails 7.1 changed the signature of this function.
-      # Checking if > 7.0.99 rather than >= 7.1 so that 7.1 pre-release versions are included.
-      COLOR_OPTIONS = if Rails.gem_version > Gem::Version.new('7.0.99')
+      COLOR_OPTIONS = if Gem::Requirement.new(">=7.1").satisfied_by?(ActiveSupport.gem_version)
         { bold: true }.freeze
       else
         true

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -72,6 +72,15 @@ module Flipper
         self.class.logger
       end
 
+      def self.attach
+        attach_to InstrumentationNamespace
+      end
+
+      def self.detach
+        # Rails 5.2 doesn't support this, that's fine
+        detach_from InstrumentationNamespace if respond_to?(:detach_from)
+      end
+
       private
 
       # Rails 7.1 changed the signature of this function.
@@ -88,5 +97,5 @@ module Flipper
     end
   end
 
-  Instrumentation::LogSubscriber.attach_to InstrumentationNamespace
+  Instrumentation::LogSubscriber.attach
 end

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -1,4 +1,4 @@
-require 'flipper/adapters/active_record'
+SpecHelpers.silence { require 'flipper/adapters/active_record' }
 require 'active_support/core_ext/kernel'
 
 # Turn off migration logging for specs
@@ -43,7 +43,7 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
 
     context "with #{config[:adapter]}" do
       before(:all) do
-        ActiveRecord::Tasks::DatabaseTasks.create(config)
+        silence { ActiveRecord::Tasks::DatabaseTasks.create(config) }
       end
 
       before(:each) do
@@ -59,7 +59,7 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
       end
 
       after(:all) do
-        ActiveRecord::Tasks::DatabaseTasks.drop(config)
+        silence { ActiveRecord::Tasks::DatabaseTasks.drop(config) }
       end
 
       it_should_behave_like 'a flipper adapter'
@@ -70,8 +70,12 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
         Flipper.configuration = nil
         Flipper.instance = nil
 
-        silence_warnings { load 'flipper/adapters/active_record.rb' }
-        expect { Flipper::Adapters::ActiveRecord.new }.not_to raise_error
+        expect {
+          silence do
+            load 'flipper/adapters/active_record.rb'
+            Flipper::Adapters::ActiveRecord.new
+          end
+        }.not_to raise_error
       end
 
       it "should load actor ids fine" do
@@ -92,7 +96,7 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
           Flipper.configuration = nil
           Flipper.instance = nil
 
-          silence_warnings { load 'flipper/adapters/active_record.rb' }
+          silence { load 'flipper/adapters/active_record.rb' }
         end
 
         it 'configures itself' do

--- a/spec/flipper/adapters/sequel_spec.rb
+++ b/spec/flipper/adapters/sequel_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Flipper::Adapters::Sequel do
       Flipper.configuration = nil
       Flipper.instance = nil
 
-      load 'flipper/adapters/sequel.rb'
+      silence { load 'flipper/adapters/sequel.rb' }
     end
 
     it 'configures itself' do

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -3,6 +3,8 @@ require 'json'
 require 'rack/test'
 
 module SpecHelpers
+  extend self
+
   def self.included(base)
     base.let(:flipper) { build_flipper }
     base.let(:app) { build_app(flipper) }
@@ -80,11 +82,11 @@ module SpecHelpers
 
     yield
 
-    $stderr = original_stderr
-    $stdout = original_stdout
-
     # Return output
     output.string
+  ensure
+    $stderr = original_stderr
+    $stdout = original_stdout
   end
 end
 

--- a/test/adapters/active_record_test.rb
+++ b/test/adapters/active_record_test.rb
@@ -47,8 +47,7 @@ class ActiveRecordTest < MiniTest::Test
     ActiveRecord::Base.table_name_prefix = :foo_
     ActiveRecord::Base.table_name_suffix = :_bar
 
-    Flipper::Adapters::ActiveRecord.send(:remove_const, :Feature)
-    Flipper::Adapters::ActiveRecord.send(:remove_const, :Gate)
+    Flipper::Adapters.send(:remove_const, :ActiveRecord)
     load("flipper/adapters/active_record.rb")
 
     assert_equal "foo_flipper_features_bar", Flipper::Adapters::ActiveRecord::Feature.table_name
@@ -58,8 +57,7 @@ class ActiveRecordTest < MiniTest::Test
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
 
-    Flipper::Adapters::ActiveRecord.send(:remove_const, :Feature)
-    Flipper::Adapters::ActiveRecord.send(:remove_const, :Gate)
+    Flipper::Adapters.send(:remove_const, :ActiveRecord)
     load("flipper/adapters/active_record.rb")
   end
 end


### PR DESCRIPTION
1. Switches to default rspec/minitest dots instead of `documentation` format
2. Silences stdout/stderr on specific tests

Now the test output is clean and it's easier to read errors and deprecation warnings.

```
$ bundle exec rake
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 45888
............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 21.05 seconds (files took 2.38 seconds to load)
2444 examples, 0 failures

Randomized with seed 45888

Run options: --seed 3894

# Running:

..................................................................................................................................................................................................................................................................................

Finished in 2.714823s, 100.9274 runs/s, 2718.0411 assertions/s.
274 runs, 7379 assertions, 0 failures, 0 errors, 0 skips
Run options: --seed 20389

# Running:

...........

Finished in 0.243952s, 45.0908 runs/s, 245.9496 assertions/s.
11 runs, 60 assertions, 0 failures, 0 errors, 0 skips
```