### PR TITLE
Add confirmation dialog before disabling a flipper

### DIFF
--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -63,6 +63,10 @@ module Flipper
       # Default is false.
       attr_accessor :confirm_fully_enable
 
+      # Public: if you want to get a confirm pop up box while disabling a feature
+      # Default is false.
+      attr_accessor :confirm_disable
+
       VALID_BANNER_CLASS_VALUES = %w(
         danger
         dark
@@ -91,6 +95,7 @@ module Flipper
         @show_feature_description_in_list = false
         @actors_separator = ','
         @confirm_fully_enable = false
+        @confirm_disable = true
         @read_only = false
       end
 

--- a/lib/flipper/ui/public/js/application.js
+++ b/lib/flipper/ui/public/js/application.js
@@ -14,13 +14,24 @@ $(function () {
       e.preventDefault();
     }
   });
-  
+
+  $("#disable_feature__button").on("click", function (e) {
+    const featureName = $(e.target).data("confirmation-text");
+    const promptMessage = prompt(
+        `Are you sure you want to disable this feature for everyone? Please enter the name of the feature to confirm it: ${featureName}`
+    );
+
+    if (promptMessage !== featureName) {
+      e.preventDefault();
+    }
+  });
+
   $("#delete_feature__button").on("click", function (e) {
     const featureName = $(e.target).data("confirmation-text");
     const promptMessage = prompt(
       `Are you sure you want to remove this feature from the list of features and disable it for everyone? Please enter the name of the feature to confirm it: ${featureName}`
     );
-    
+
     if (promptMessage !== featureName) {
       e.preventDefault();
     }

--- a/lib/flipper/ui/public/js/application.js
+++ b/lib/flipper/ui/public/js/application.js
@@ -18,7 +18,7 @@ $(function () {
   $("#disable_feature__button").on("click", function (e) {
     const featureName = $(e.target).data("confirmation-text");
     const promptMessage = prompt(
-        `Are you sure you want to disable this feature for everyone? Please enter the name of the feature to confirm it: ${featureName}`
+      `Are you sure you want to disable this feature for everyone? Please enter the name of the feature to confirm it: ${featureName}`
     );
 
     if (promptMessage !== featureName) {
@@ -31,7 +31,7 @@ $(function () {
     const promptMessage = prompt(
       `Are you sure you want to remove this feature from the list of features and disable it for everyone? Please enter the name of the feature to confirm it: ${featureName}`
     );
-
+    
     if (promptMessage !== featureName) {
       e.preventDefault();
     }

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -263,8 +263,13 @@
 
               <% unless @feature.off? %>
                 <div class="col">
-                  <button type="submit" name="action" value="Disable" class="btn btn-outline-danger btn-block">
-                    <span class="d-block" data-toggle="tooltip" title="Disable for everyone by clearing all percentages, groups and actors.">
+                  <button type="submit" name="action" value="Disable" <% if Flipper::UI.configuration.confirm_disable %>id="disable_feature__button"<% end %> class="btn btn-outline-danger btn-block">
+                    <span class="d-block" data-toggle="tooltip"
+                      <% if Flipper::UI.configuration.confirm_disable %>
+                        data-confirmation-text="<%= feature_name %>"
+                      <% end %>
+                          title="Disable for everyone by clearing all percentages, groups and actors."
+                      >
                       Disable
                     </span>
                   </button>

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -268,7 +268,7 @@
                       <% if Flipper::UI.configuration.confirm_disable %>
                         data-confirmation-text="<%= feature_name %>"
                       <% end %>
-                          title="Disable for everyone by clearing all percentages, groups and actors."
+                        title="Disable for everyone by clearing all percentages, groups and actors."
                       >
                       Disable
                     </span>


### PR DESCRIPTION
Similar to https://github.com/flippercloud/flipper/pull/665, this PR adds a confirmation dialog when disabling a flipper. The dialog is configurable with `confirm_disable`.