### PR TITLE
Disable strict in tests for now

### DIFF
--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -9,8 +9,8 @@ module Flipper
       elsif Rails.env.production?
         false
       else
-        # Warn for now. Future versions will default to :raise in development and test
-        :warn
+        # Warn in development for now. Future versions may default to :raise in development and test
+        Rails.env.development? && :warn
       end
     end
 

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -73,22 +73,30 @@ RSpec.describe Flipper::Engine do
       expect(adapter).to be_instance_of(Flipper::Adapters::Memory)
     end
 
-    it "defaults to strict=false in RAILS_ENV=production" do
-      Rails.env = "production"
+    it "defaults to strict=:warn in RAILS_ENV=development" do
+      Rails.env = "development"
       subject
-      expect(config.strict).to eq(false)
-      expect(adapter).to be_instance_of(Flipper::Adapters::Memory)
+      expect(config.strict).to eq(:warn)
+      expect(adapter).to be_instance_of(Flipper::Adapters::Strict)
     end
 
-    %w(development test).each do |env|
+    %w(production test).each do |env|
       it "defaults to strict=warn in RAILS_ENV=#{env}" do
         Rails.env = env
         expect(Rails.env).to eq(env)
         subject
-        expect(config.strict).to eq(:warn)
-        expect(adapter).to be_instance_of(Flipper::Adapters::Strict)
-        expect(adapter.handler).to be(:warn)
+        expect(config.strict).to eq(false)
+        expect(adapter).to be_instance_of(Flipper::Adapters::Memory)
       end
+    end
+
+    it "defaults to strict=warn in RAILS_ENV=development" do
+      Rails.env = "development"
+      expect(Rails.env).to eq("development")
+      subject
+      expect(config.strict).to eq(:warn)
+      expect(adapter).to be_instance_of(Flipper::Adapters::Strict)
+      expect(adapter.handler).to be(:warn)
     end
   end
 


### PR DESCRIPTION
Until we come up with a recommended way of declaring features, @jnunemaker and I talked and decided it's best to just disable the strict adapter in tests for now. It will still `:warn` in development, and those that want it can explicitly enable it in test, but the default is just too noisy at the moment.

cc #807 