### PR TITLE
Generate a default initializer

### DIFF
--- a/lib/generators/flipper/setup_generator.rb
+++ b/lib/generators/flipper/setup_generator.rb
@@ -4,9 +4,14 @@ module Flipper
   module Generators
     class SetupGenerator < ::Rails::Generators::Base
       desc 'Peform any necessary steps to install Flipper'
+      source_paths << File.expand_path('templates', __dir__)
 
       class_option :token, type: :string, default: nil, aliases: '-t',
         desc: "Your personal environment token for Flipper Cloud"
+
+      def generate_initializer
+        template 'initializer.rb', 'config/initializers/flipper.rb'
+      end
 
       def generate_active_record
         invoke 'flipper:active_record' if defined?(Flipper::Adapters::ActiveRecord)

--- a/lib/generators/flipper/templates/initializer.rb
+++ b/lib/generators/flipper/templates/initializer.rb
@@ -1,0 +1,35 @@
+Rails.application.configure do
+  ## Memoization ensures that only one adapter call is made per feature per request.
+  ## For more info, see https://www.flippercloud.io/docs/optimization#memoization
+  # config.flipper.memoize = true
+
+  ## Flipper preloads all features before each request, which is recommended if:
+  ##   * you have a limited number of features (< 100?)
+  ##   * most of your requests depend on most of your features
+  ##   * you have limited gate data combined across all features (< 1k enabled gates, like individual actors, across all features)
+  ##
+  ## For more info, see https://www.flippercloud.io/docs/optimization#preloading
+  # config.flipper.preload = [:only, :these, :common, :features]
+
+  ## Warn or raise an error if an unknown feature is checked
+  ## Can be set to `:warn`, `:raise`, or `false`
+  # config.flipper.strict = Rails.env.development? && :warn
+
+  ## Show Flipper checks in logs
+  # config.flipper.log = true
+
+  ## Reconfigure Flipper to use the Memory adaper and disable Cloud in tests
+  # config.flipper.test_help = true
+
+  ## The path that Flipper Cloud will use to sync features
+  # config.flipper.cloud_path = "_flipper"
+
+  ## The instrumenter that Flipper will use. Defaults to ActiveSupport::Notifications.
+  # config.flipper.instrumenter = ActiveSupport::Notifications
+end
+
+Flipper.configure do |config|
+  ## Configure other adapters that you want to use here:
+  ## See http://flippercloud.io/docs/adapters
+  # config.use Flipper::Adapters::ActiveSupportCacheStore, Rails.cache, expires_in: 5.minutes
+end

--- a/lib/generators/flipper/templates/initializer.rb
+++ b/lib/generators/flipper/templates/initializer.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   ##   * you have limited gate data combined across all features (< 1k enabled gates, like individual actors, across all features)
   ##
   ## For more info, see https://www.flippercloud.io/docs/optimization#preloading
-  # config.flipper.preload = [:only, :these, :common, :features]
+  # config.flipper.preload = true
 
   ## Warn or raise an error if an unknown feature is checked
   ## Can be set to `:warn`, `:raise`, or `false`
@@ -33,3 +33,13 @@ Flipper.configure do |config|
   ## See http://flippercloud.io/docs/adapters
   # config.use Flipper::Adapters::ActiveSupportCacheStore, Rails.cache, expires_in: 5.minutes
 end
+
+## Register a group that can be used for enabling features.
+##
+##   Flipper.enable_group :my_feature, :admins
+##
+## See https://www.flippercloud.io/docs/features#enablement-group
+#
+# Flipper.register(:admins) do |actor|
+#  actor.respond_to?(:admin?) && actor.admin?
+# end

--- a/test_rails/generators/flipper/setup_generator_test.rb
+++ b/test_rails/generators/flipper/setup_generator_test.rb
@@ -17,6 +17,11 @@ class SetupGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "generates an initializer" do
+    run_generator
+    assert_file 'config/initializers/flipper.rb', /Flipper\.configure/
+  end
+
   test "does not invoke flipper:active_record generator if ActiveRecord adapter not defined" do
     # Ensure adapter not defined
     Flipper::Adapters.send(:remove_const, :ActiveRecord) rescue nil


### PR DESCRIPTION
This adds `config/initializers/flipper.rb` to the `flipper:setup` generator, which which documents the configuration options (and their defaults).