### PR TITLE
Check existence of RSpec.configure for test helpers

### DIFF
--- a/lib/flipper/test_help.rb
+++ b/lib/flipper/test_help.rb
@@ -16,7 +16,7 @@ module Flipper
   end
 end
 
-if defined?(RSpec) && RSpec.methods.include?(:configure)
+if defined?(RSpec) && RSpec.respond_to?(:configure)
   RSpec.configure do |config|
     config.include Flipper::TestHelp
     config.before(:all) { flipper_configure }

--- a/lib/flipper/test_help.rb
+++ b/lib/flipper/test_help.rb
@@ -16,7 +16,7 @@ module Flipper
   end
 end
 
-if defined?(RSpec)
+if defined?(RSpec) && RSpec.methods.include?(:configure)
   RSpec.configure do |config|
     config.include Flipper::TestHelp
     config.before(:all) { flipper_configure }


### PR DESCRIPTION
When Rails commands such as db:migrate are executed (formerly rake tasks), they load the broader set of rake tasks, and that means that RSpec's rake task is loaded **without all of the RSpec context**.

This means there _is_ an RSpec constant (from lib/rspec/core/rake_task.rb in rspec-core), but it does not have the configure method. This causes the commands to fail because Flipper's presuming `configure` will always be there if `RSpec` is defined:

```
NoMethodError: undefined method `configure' for RSpec:Module (NoMethodError)

  RSpec.configure do |config|
       ^^^^^^^^^^
/Users/pat/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/flipper-1.2.0/lib/flipper/test_help.rb:20:in `<main>'
```

I considered loading `rspec/core` here instead to ensure the method exists, but that feels counter to what's actually needed: i.e. only if we have that full RSpec context should we be adding the Flipper helpers.

If we don't have RSpec fully loaded, then we should respect the current context, not choose to load RSpec unexpectedly, and so not add Flipper's helpers.