### PR TITLE
Ensure Rspec uses new memory adapter for each example

### DIFF
--- a/lib/flipper/test_help.rb
+++ b/lib/flipper/test_help.rb
@@ -19,8 +19,10 @@ end
 if defined?(RSpec) && RSpec.respond_to?(:configure)
   RSpec.configure do |config|
     config.include Flipper::TestHelp
-    config.before(:all) { flipper_configure }
-    config.before(:each) { flipper_reset }
+    config.before(:each) do
+      flipper_reset
+      flipper_configure
+    end
   end
 end
 


### PR DESCRIPTION
As mentioned in https://github.com/flippercloud/flipper/pull/808#discussion_r1452290722, the current RSpec integration does not clear the state of the adapter between specs. This is being obscured in our test suite at the moment because of how we manually clear `Flipper.configuration = nil`.

For now the fix is just to reconfigure Flipper before each example, which will create a new Memory adapter for each test (which is what it does with Rails+minitest).