### PR TITLE
Add irb gem depencency

### DIFF
--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'concurrent-ruby', '< 2'
+  gem.add_dependency 'irb', '~> 1.0'
 
   gem.required_ruby_version = ">= #{Flipper::REQUIRED_RUBY_VERSION}"
 end

--- a/lib/flipper/cli.rb
+++ b/lib/flipper/cli.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'irb/color'
 
 module Flipper
   class CLI < OptionParser


### PR DESCRIPTION
Fixes #817 

The new CLI (#630) uses `IRB` for colorization. Well, it turns out that irb is now distributed as a gem. Our test suite is passing because `debug` and `rails` ~>7.1 both depend on the `irb` gem, so it was obscuring the issue.

I tried making colorization in the CLI optional, but couldn't figure out a clean way to detect if IRB was loaded from a gem or bundled with Ruby.