### PR TITLE
TestHelp: Fix setup for RSpec, clear adapter before each test

### DIFF
--- a/test_rails/system/test_help_test.rb
+++ b/test_rails/system/test_help_test.rb
@@ -31,8 +31,13 @@ class TestHelpTest < ActionDispatch::SystemTestCase
   # Any driver that runs the app in a separate thread will test what we want here.
   driven_by :cuprite, options: { process_timeout: 30 }
 
-  # Ensure this test uses this app instance
-  setup { Rails.application = TestApp.instance }
+  setup do
+    # Reconfigure Flipper since other tests change the adapter.
+    flipper_configure
+
+    # Ensure this test uses this app instance
+    Rails.application = TestApp.instance
+  end
 
   test "configures a shared adapter between tests and app" do
     Flipper.disable(:test)


### PR DESCRIPTION
This should fix #821 and fix #822.

I can't get a failing RSpec spec in this repo right now, but will work on refactoring our test suite to get one similar to `test_rails/system/test_help_test.rb` for rspec.

@danielmorrison @norman @rnestler @davidwessman @fcheung can you test this branch and confirm that it works for you?

cc #808 

