### PR TITLE
Support Rack 3

### DIFF
--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'rack', '>= 1.4', '< 4'
-  gem.add_dependency 'rack-protection', '>= 1.5.3', '<= 4.0.0'
+  gem.add_dependency 'rack-protection', '>= 1.5.3', '<5.0.0'
+  gem.add_dependency 'rack-session', '>= 1.0.2', '< 3.0.0'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'erubi', '>= 1.0.0', '< 2.0.0'
   gem.add_dependency 'sanitize', '< 7'

--- a/lib/flipper/api/json_params.rb
+++ b/lib/flipper/api/json_params.rb
@@ -12,6 +12,7 @@ module Flipper
       CONTENT_TYPE = 'CONTENT_TYPE'.freeze
       QUERY_STRING = 'QUERY_STRING'.freeze
       REQUEST_BODY = 'rack.input'.freeze
+      REWIND_BODY = Gem::Version.new(Rack.release) < Gem::Version.new('3.0.0')
 
       # Public: Merge request body params with query string params
       # This way can access all params with Rack::Request#params
@@ -21,7 +22,7 @@ module Flipper
       def call(env)
         if env[CONTENT_TYPE] == 'application/json'
           body = env[REQUEST_BODY].read
-          env[REQUEST_BODY].rewind
+          env[REQUEST_BODY].rewind if REWIND_BODY
           update_params(env, body)
         end
         @app.call(env)

--- a/lib/flipper/api/v1/actions/import.rb
+++ b/lib/flipper/api/v1/actions/import.rb
@@ -10,8 +10,11 @@ module Flipper
           route %r{\A/import/?\Z}
 
           def post
+            # Rack 3 changed the requirement to rewind the body, so we can't assume it is rewound,
+            # so rewind before under Rack 3+ and after under Rack 2.
+            request.body.rewind if Gem::Version.new(Rack.release) >= Gem::Version.new('3.0.0')
             body = request.body.read
-            request.body.rewind
+            request.body.rewind if Gem::Version.new(Rack.release) < Gem::Version.new('3.0.0')
             export = Flipper::Exporters::Json::Export.new(contents: body)
             flipper.import(export)
             json_response({}, 204)

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -1,6 +1,15 @@
 require 'flipper/adapters/http'
 require 'flipper/adapters/pstore'
-require 'rack/handler/webrick'
+
+rack_handler = begin
+  # Rack 3+
+  require 'rackup/handler/webrick'
+  Rackup::Handler::WEBrick
+rescue LoadError
+  require 'rack/handler/webrick'
+  Rack::Handler::WEBrick
+end
+
 
 FLIPPER_SPEC_API_PORT = ENV.fetch('FLIPPER_SPEC_API_PORT', 9001).to_i
 
@@ -36,7 +45,7 @@ RSpec.describe Flipper::Adapters::Http do
           ],
         }
         @server = WEBrick::HTTPServer.new(server_options)
-        @server.mount '/', Rack::Handler::WEBrick, app
+        @server.mount '/', rack_handler, app
 
         Thread.new { @server.start }
         Timeout.timeout(1) { :wait until @started }

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -1,6 +1,7 @@
 require 'ice_age'
 require 'json'
 require 'rack/test'
+require 'rack/session'
 
 module SpecHelpers
   extend self
@@ -12,7 +13,7 @@ module SpecHelpers
 
   def build_app(flipper, options = {})
     Flipper::UI.app(flipper, options) do |builder|
-      builder.use Rack::Session::Cookie, secret: 'test'
+      builder.use Rack::Session::Cookie, secret: 'test' * 16 # Rack 3+ wants a 64-character secret
     end
   end
 


### PR DESCRIPTION
Add support for Rack 3. 

Flipper UI's dependency on`rack-protection` was locking the `rack` version to 2x. Now that `rack-protection` 4 is out, we can update `rack`. This brings up a good question: should Flipper UI require `rack-protection`? I like it and all, but might not be Flipper's responsibility. 🤷 

`rack-session` has been extracted from `rack`, but has versions to work under rack 2 or 3.

I have a couple import-related tests failing locally, but haven't figured out exactly why yet. The `request.body` isn't coming through (the body is a `Rackup::Handler::WEBrick::Input` and `.rewind` rails, but trying to `.read` returns `""`).