### PR TITLE
Fix: Respect Rails defaults in an initializer by delaying loading ActiveRecord adapter until framework is loaded

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -7,34 +7,36 @@ module Flipper
     class ActiveRecord
       include ::Flipper::Adapter
 
-      # Abstract base class for internal models
-      class Model < ::ActiveRecord::Base
-        self.abstract_class = true
-      end
+      ActiveSupport.on_load(:active_record) do
+        # Abstract base class for internal models
+        class Model < ::ActiveRecord::Base
+          self.abstract_class = true
+        end
 
-      # Private: Do not use outside of this adapter.
-      class Feature < Model
-        self.table_name = [
-          Model.table_name_prefix,
-          "flipper_features",
-          Model.table_name_suffix,
-        ].join
+        # Private: Do not use outside of this adapter.
+        class Feature < Model
+          self.table_name = [
+            Model.table_name_prefix,
+            "flipper_features",
+            Model.table_name_suffix,
+          ].join
 
-        has_many :gates, foreign_key: "feature_key", primary_key: "key"
+          has_many :gates, foreign_key: "feature_key", primary_key: "key"
 
-        validates :key, presence: true
-      end
+          validates :key, presence: true
+        end
 
-      # Private: Do not use outside of this adapter.
-      class Gate < Model
-        self.table_name = [
-          Model.table_name_prefix,
-          "flipper_gates",
-          Model.table_name_suffix,
-        ].join
+        # Private: Do not use outside of this adapter.
+        class Gate < Model
+          self.table_name = [
+            Model.table_name_prefix,
+            "flipper_gates",
+            Model.table_name_suffix,
+          ].join
 
-        validates :feature_key, presence: true
-        validates :key, presence: true
+          validates :feature_key, presence: true
+          validates :key, presence: true
+        end
       end
 
       VALUE_TO_TEXT_WARNING = <<-EOS


### PR DESCRIPTION
The Flipper models are loading too soon and causing weirdness with saving models that have a belongs_to. The belongs_to association is being loaded on save even when there have not been any changes to the association.

BEFORE
```ruby
irb(main):001> token = OrganizationAccessToken.find(1)
...
irb(main):002> token.update(description: 'a token')
DEBUG:   TRANSACTION (0.7ms)  BEGIN
DEBUG:   Organization Load (1.0ms)  SELECT "organizations".* FROM "organizations" WHERE "organizations"."status" != $1 AND "organizations"."id" = $2 LIMIT $3  [["status", "deactivated"], ["id", 3], ["LIMIT", 1]]
DEBUG:   OrganizationAccessToken Update (1.0ms)  UPDATE "organization_access_tokens" SET "description" = $1, "updated_at" = $2 WHERE "organization_access_tokens"."id" = $3  [["description", "a token"], ["updated_at", "2024-01-31 22:19:38.068599"], ["id", 1]]
DEBUG:   TRANSACTION (1.4ms)  COMMIT
=> true
```

AFTER
```ruby
irb(main):001> token = OrganizationAccessToken.find(1)
...
irb(main):002> token.update(description: 'a token')
DEBUG:   TRANSACTION (0.7ms)  BEGIN
DEBUG:   OrganizationAccessToken Update (1.8ms)  UPDATE "organization_access_tokens" SET "description" = $1, "updated_at" = $2 WHERE "organization_access_tokens"."id" = $3  [["description", "a token"], ["updated_at", "2024-01-31 22:21:21.908915"], ["id", 1]]
DEBUG:   TRANSACTION (0.9ms)  COMMIT
=> true
```