### PR TITLE
Fail specs if any output

### DIFF
--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -1,5 +1,4 @@
 SpecHelpers.silence { require 'flipper/adapters/active_record' }
-require 'active_support/core_ext/hash/indifferent_access'
 
 # Turn off migration logging for specs
 ActiveRecord::Migration.verbose = false

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -16,212 +16,217 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
 
   [
     {
-      adapter: "sqlite3",
-      database: ":memory:"
+      "adapter" => "sqlite3",
+      "database" => ":memory:"
     },
 
     {
-      adapter: "mysql2",
-      encoding: "utf8mb4",
-      username: ENV["MYSQL_USER"] || "root",
-      password: ENV["MYSQL_PASSWORD"] || "",
-      database: ENV["MYSQL_DATABASE"] || "flipper_test",
-      port: ENV["DB_PORT"] || 3306
+      "adapter" => "mysql2",
+      "encoding" => "utf8mb4",
+      "username" => ENV["MYSQL_USER"] || "root",
+      "password" => ENV["MYSQL_PASSWORD"] || "",
+      "database" => ENV["MYSQL_DATABASE"] || "flipper_test",
+      "port" => ENV["DB_PORT"] || 3306
     },
 
     {
-      adapter: "postgresql",
-      encoding: "unicode",
-      host: "127.0.0.1",
-      username: ENV["POSTGRES_USER"] || "",
-      password: ENV["POSTGRES_PASSWORD"] || "",
-      database: ENV["POSTGRES_DATABASE"] || "flipper_test",
+      "adapter" => "postgresql",
+      "encoding" => "unicode",
+      "host" => "127.0.0.1",
+      "username" => ENV["POSTGRES_USER"] || "",
+      "password" => ENV["POSTGRES_PASSWORD"] || "",
+      "database" => ENV["POSTGRES_DATABASE"] || "flipper_test",
     }
   ].each do |config|
-    config = config.with_indifferent_access
+    context "with #{config['adapter']}" do
+      context "with tables created" do
+        before(:all) do
+          skip_on_error(ActiveRecord::ConnectionNotEstablished, "#{config['adapter']} not available") do
+            silence { ActiveRecord::Tasks::DatabaseTasks.create(config) }
+          end
 
-    context "with #{config[:adapter]}" do
-      before(:all) do
-        silence { ActiveRecord::Tasks::DatabaseTasks.create(config) }
-      end
+          Flipper.configuration = nil
+        end
 
-      before(:each) do
-        skip_on_error(ActiveRecord::ConnectionNotEstablished, "#{config[:adapter]} not available") do
-          ActiveRecord::Base.establish_connection(config)
-          CreateFlipperTables.migrate(:up)
+        before(:each) do
+          skip_on_error(ActiveRecord::ConnectionNotEstablished, "#{config['adapter']} not available") do
+            ActiveRecord::Base.establish_connection(config)
+            CreateFlipperTables.migrate(:up)
+          end
+        end
+
+        after(:each) do
+          ActiveRecord::Tasks::DatabaseTasks.purge(config)
+          ActiveRecord::Base.connection.close
+        end
+
+        after(:all) do
+          silence { ActiveRecord::Tasks::DatabaseTasks.drop(config) } unless $skip
+        end
+
+        it_should_behave_like 'a flipper adapter'
+
+        it "should load actor ids fine" do
+          flipper.enable_percentage_of_time(:foo, 1)
+
+          Flipper::Adapters::ActiveRecord::Gate.create!(
+            feature_key: "foo",
+            key: "actors",
+            value: "Organization;4",
+          )
+
+          flipper = Flipper.new(subject)
+          flipper.preload([:foo])
+        end
+
+        context "ActiveRecord connection_pool" do
+          before do
+            ActiveRecord::Base.connection_handler.clear_active_connections!
+          end
+
+          context "#features" do
+            it "does not hold onto connections" do
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.features
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+            end
+
+            it "does not release previously held connection" do
+              ActiveRecord::Base.connection # establish a new connection
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.features
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+            end
+          end
+
+          context "#get_all" do
+            it "does not hold onto connections" do
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.get_all
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+            end
+
+            it "does not release previously held connection" do
+              ActiveRecord::Base.connection # establish a new connection
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.get_all
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+            end
+          end
+
+          context "#add / #remove / #clear" do
+            let(:feature) { Flipper::Feature.new(:search, subject) }
+
+            it "does not hold onto connections" do
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.add(feature)
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.remove(feature)
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.clear(feature)
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+            end
+
+            it "does not release previously held connection" do
+              ActiveRecord::Base.connection # establish a new connection
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.add(feature)
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.remove(feature)
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.clear(feature)
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+            end
+          end
+
+          context "#get_multi" do
+            let(:feature) { Flipper::Feature.new(:search, subject) }
+
+            it "does not hold onto connections" do
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.get_multi([feature])
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+            end
+
+            it "does not release previously held connection" do
+              ActiveRecord::Base.connection # establish a new connection
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.get_multi([feature])
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+            end
+          end
+
+          context "#enable/#disable boolean" do
+            let(:feature) { Flipper::Feature.new(:search, subject) }
+            let(:gate) { feature.gate(:boolean)}
+
+            it "does not hold onto connections" do
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.enable(feature, gate, gate.wrap(true))
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.disable(feature, gate, gate.wrap(false))
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+            end
+
+            it "does not release previously held connection" do
+              ActiveRecord::Base.connection # establish a new connection
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.enable(feature, gate, gate.wrap(true))
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.disable(feature, gate, gate.wrap(false))
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+            end
+          end
+
+          context "#enable/#disable set" do
+            let(:feature) { Flipper::Feature.new(:search, subject) }
+            let(:gate) { feature.gate(:group) }
+
+            it "does not hold onto connections" do
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.enable(feature, gate, gate.wrap(:admin))
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+              subject.disable(feature, gate, gate.wrap(:admin))
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
+            end
+
+            it "does not release previously held connection" do
+              ActiveRecord::Base.connection # establish a new connection
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.enable(feature, gate, gate.wrap(:admin))
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+              subject.disable(feature, gate, gate.wrap(:admin))
+              expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
+            end
+          end
+        end
+
+        context 'requiring "flipper-active_record"' do
+          before do
+            Flipper.configuration = nil
+            Flipper.instance = nil
+
+            silence { load 'flipper/adapters/active_record.rb' }
+          end
+
+          it 'configures itself' do
+            expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::ActiveRecord)
+          end
         end
       end
 
-      after(:each) do
-        ActiveRecord::Tasks::DatabaseTasks.purge(config)
-        ActiveRecord::Base.connection.close
-      end
-
-      after(:all) do
-        silence { ActiveRecord::Tasks::DatabaseTasks.drop(config) }
-      end
-
-      it_should_behave_like 'a flipper adapter'
-
       it "works when table doesn't exist" do
-        CreateFlipperTables.migrate(:down)
 
         Flipper.configuration = nil
         Flipper.instance = nil
 
-        expect {
-          silence do
+        Flipper::Adapters.send(:remove_const, :ActiveRecord) if Flipper::Adapters.const_defined?(:ActiveRecord)
+
+        silence do
+          expect {
             load 'flipper/adapters/active_record.rb'
             Flipper::Adapters::ActiveRecord.new
-          end
-        }.not_to raise_error
-      end
-
-      it "should load actor ids fine" do
-        flipper.enable_percentage_of_time(:foo, 1)
-
-        Flipper::Adapters::ActiveRecord::Gate.create!(
-          feature_key: "foo",
-          key: "actors",
-          value: "Organization;4",
-        )
-
-        flipper = Flipper.new(subject)
-        flipper.preload([:foo])
-      end
-
-      context 'requiring "flipper-active_record"' do
-        before do
-          Flipper.configuration = nil
-          Flipper.instance = nil
-
-          silence { load 'flipper/adapters/active_record.rb' }
-        end
-
-        it 'configures itself' do
-          expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::ActiveRecord)
-        end
-      end
-
-      context "ActiveRecord connection_pool" do
-        before do
-          ActiveRecord::Base.clear_active_connections!
-        end
-
-        context "#features" do
-          it "does not hold onto connections" do
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.features
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-          end
-
-          it "does not release previously held connection" do
-            ActiveRecord::Base.connection # establish a new connection
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.features
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-          end
-        end
-
-        context "#get_all" do
-          it "does not hold onto connections" do
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.get_all
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-          end
-
-          it "does not release previously held connection" do
-            ActiveRecord::Base.connection # establish a new connection
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.get_all
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-          end
-        end
-
-        context "#add / #remove / #clear" do
-          let(:feature) { Flipper::Feature.new(:search, subject) }
-
-          it "does not hold onto connections" do
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.add(feature)
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.remove(feature)
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.clear(feature)
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-          end
-
-          it "does not release previously held connection" do
-            ActiveRecord::Base.connection # establish a new connection
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.add(feature)
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.remove(feature)
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.clear(feature)
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-          end
-        end
-
-        context "#get_multi" do
-          let(:feature) { Flipper::Feature.new(:search, subject) }
-
-          it "does not hold onto connections" do
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.get_multi([feature])
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-          end
-
-          it "does not release previously held connection" do
-            ActiveRecord::Base.connection # establish a new connection
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.get_multi([feature])
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-          end
-        end
-
-        context "#enable/#disable boolean" do
-          let(:feature) { Flipper::Feature.new(:search, subject) }
-          let(:gate) { feature.gate(:boolean)}
-
-          it "does not hold onto connections" do
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.enable(feature, gate, gate.wrap(true))
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.disable(feature, gate, gate.wrap(false))
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-          end
-
-          it "does not release previously held connection" do
-            ActiveRecord::Base.connection # establish a new connection
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.enable(feature, gate, gate.wrap(true))
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.disable(feature, gate, gate.wrap(false))
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-          end
-        end
-
-        context "#enable/#disable set" do
-          let(:feature) { Flipper::Feature.new(:search, subject) }
-          let(:gate) { feature.gate(:group) }
-
-          it "does not hold onto connections" do
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.enable(feature, gate, gate.wrap(:admin))
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-            subject.disable(feature, gate, gate.wrap(:admin))
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(false)
-          end
-
-          it "does not release previously held connection" do
-            ActiveRecord::Base.connection # establish a new connection
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.enable(feature, gate, gate.wrap(:admin))
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-            subject.disable(feature, gate, gate.wrap(:admin))
-            expect(ActiveRecord::Base.connection_handler.active_connections?).to be(true)
-          end
+          }.not_to raise_error
         end
       end
     end

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -4,6 +4,7 @@ require 'flipper/engine'
 RSpec.describe Flipper::Engine do
   let(:application) do
     Class.new(Rails::Application) do
+      config.load_defaults Rails::VERSION::STRING.to_f
       config.eager_load = false
       config.logger = ActiveSupport::Logger.new($stdout)
     end.instance

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Flipper::Engine do
       config.load_defaults Rails::VERSION::STRING.to_f
       config.eager_load = false
       config.logger = ActiveSupport::Logger.new($stdout)
+      config.active_support.remove_deprecated_time_with_zone_name = false
     end.instance
   end
 

--- a/spec/support/fail_on_output.rb
+++ b/spec/support/fail_on_output.rb
@@ -1,4 +1,4 @@
-if ENV["CI"] || ENV["FAIL_ON_STDOUT"]
+if ENV["CI"] || ENV["FAIL_ON_OUTPUT"]
   RSpec.configure do |config|
     config.around do |example|
       output = silence { example.run }

--- a/spec/support/fail_on_stdout.rb
+++ b/spec/support/fail_on_stdout.rb
@@ -1,0 +1,8 @@
+if ENV["CI"] || ENV["FAIL_ON_STDOUT"]
+  RSpec.configure do |config|
+    config.around do |example|
+      output = silence { example.run }
+      fail "Use `silence { }` to avoid printing to STDOUT/STDERR\n#{output}" unless output.empty?
+    end
+  end
+end


### PR DESCRIPTION
#811 cleaned up most of the noise, but there was still a few stray warnings. This updates the specs to fail if there is any output to stdout/stderr if `ENV["CI"]` or `ENV["FAIL_ON_OUTPUT"]` are set, and fixies the remaining warnings.