### PR TITLE
ConnectionPool adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'mysql2'
 gem 'pg'
 gem 'cuprite'
 gem 'puma'
+gem 'connection_pool'
 
 group(:guard) do
   gem 'guard'

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -1,6 +1,20 @@
 module Flipper
   # Adding a module include so we have some hooks for stuff down the road
   module Adapter
+    OPERATIONS = [
+      :add,
+      :clear,
+      :disable,
+      :enable,
+      :export,
+      :features,
+      :get_all,
+      :get_multi,
+      :get,
+      :import,
+      :remove,
+    ]
+
     def self.included(base)
       base.extend(ClassMethods)
     end

--- a/lib/flipper/adapters/connection_pool.rb
+++ b/lib/flipper/adapters/connection_pool.rb
@@ -2,26 +2,41 @@
 #
 # Usage:
 #
+#   # Reuse an existing pool to create new adapters
 #   pool = ConnectionPool.new(size: 5, timeout: 5) { Redis.new }
 #   Flipper::Adapters::ConnectionPool.new(pool) do |client|
 #     Flipper::Adapters::Redis.new(client)
 #   end
 #
+#   # Create a new pool that returns the adapter
+#   Flipper::Adapters::ConnectionPool.new(size: 5, timeout: 5) do
+#     Flipper::Adapters::Redis.new(Redis.new)
+#   end
 class Flipper::Adapters::ConnectionPool
   include Flipper::Adapter
 
-  def initialize(pool = nil, &adapter_initializer)
-    @pool = pool
-    @adapter_initializer = adapter_initializer
-    @adapter_cache = {}
+  # Use an existing ConnectionPool to initialize and cache new adapter instances.
+  class Wrapper
+    def initialize(pool, &initializer)
+      @pool = pool
+      @initializer = initializer
+      @instances = {}
+    end
+
+    def with(&block)
+      @pool.with do |resource|
+        yield @instances[resource] ||= @initializer.call(resource)
+      end
+    end
+  end
+
+  def initialize(options = {}, &adapter_initializer)
+    @pool = options.is_a?(ConnectionPool) ? Wrapper.new(options, &adapter_initializer) : ConnectionPool.new(options, &adapter_initializer)
   end
 
   OPERATIONS.each do |method|
     define_method(method) do |*args|
-      @pool.with do |connection|
-        @adapter_cache[connection] ||= @adapter_initializer.call(connection)
-        @adapter_cache[connection].public_send(method, *args)
-      end
+      @pool.with { |adapter| adapter.public_send(method, *args) }
     end
   end
 end

--- a/lib/flipper/adapters/connection_pool.rb
+++ b/lib/flipper/adapters/connection_pool.rb
@@ -13,12 +13,14 @@ class Flipper::Adapters::ConnectionPool
   def initialize(pool = nil, &adapter_initializer)
     @pool = pool
     @adapter_initializer = adapter_initializer
+    @adapter_cache = {}
   end
 
   OPERATIONS.each do |method|
     define_method(method) do |*args|
       @pool.with do |connection|
-        @adapter_initializer.call(connection).public_send(method, *args)
+        @adapter_cache[connection] ||= @adapter_initializer.call(connection)
+        @adapter_cache[connection].public_send(method, *args)
       end
     end
   end

--- a/lib/flipper/adapters/connection_pool.rb
+++ b/lib/flipper/adapters/connection_pool.rb
@@ -1,0 +1,25 @@
+# An adapter that uses ConnectionPool to manage connections.
+#
+# Usage:
+#
+#   pool = ConnectionPool.new(size: 5, timeout: 5) { Redis.new }
+#   Flipper::Adapters::ConnectionPool.new(pool) do |client|
+#     Flipper::Adapters::Redis.new(client)
+#   end
+#
+class Flipper::Adapters::ConnectionPool
+  include Flipper::Adapter
+
+  def initialize(pool = nil, &adapter_initializer)
+    @pool = pool
+    @adapter_initializer = adapter_initializer
+  end
+
+  OPERATIONS.each do |method|
+    define_method(method) do |*args|
+      @pool.with do |connection|
+        @adapter_initializer.call(connection).public_send(method, *args)
+      end
+    end
+  end
+end

--- a/spec/flipper/adapters/connection_pool_spec.rb
+++ b/spec/flipper/adapters/connection_pool_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Flipper::Adapters::ConnectionPool do
     end
 
     it_should_behave_like 'a flipper adapter'
+
+    it "should reset the cache when the pool is reloaded or shutdown" do
+      subject.get_all
+      expect { pool.reload { |_| } }.to change { subject.pool.instance_variable_get(:@instances).size }.from(1).to(0)
+      subject.get_all
+      expect { pool.shutdown { |_| } }.to change { subject.pool.instance_variable_get(:@instances).size }.from(1).to(0)
+    end
   end
 
   context "with a new pool" do

--- a/spec/flipper/adapters/connection_pool_spec.rb
+++ b/spec/flipper/adapters/connection_pool_spec.rb
@@ -1,0 +1,24 @@
+require "connection_pool"
+require "flipper/adapters/connection_pool"
+require "flipper-redis"
+
+RSpec.describe Flipper::Adapters::ConnectionPool do
+  let(:pool) do
+    ConnectionPool.new(size: 1, timeout: 5) do
+      Redis.new({url: ENV['REDIS_URL']}.compact)
+    end
+  end
+
+  subject do
+    described_class.new(pool) { |client| Flipper::Adapters::Redis.new(client) }
+  end
+
+  before do
+    skip_on_error(Redis::CannotConnectError, 'Redis not available') do
+      pool.with(&:flushdb)
+    end
+  end
+
+
+  it_should_behave_like 'a flipper adapter'
+end


### PR DESCRIPTION
This is an attempt at creating a generic `ConnectionPool` adapter that can be composed with other adapters as discussed in https://github.com/flippercloud/flipper/pull/826#pullrequestreview-1832444441.

It just wraps each adapter method call in a `pool.with { }` call, but I think this mostly makes sense since the adapter API already represents atomic actions.  It's not a lot of code and can be used with any adapter that requires a connection pool (`Redis`, `RedisCache`, and probably others).

`ConnectionPool` doesn't expose a mechanism for extending an existing pool instance, caching objects that depend on connection, or obsevering lifecycle events, so this adapter has to keep a cache of adapter instances for each connection. I'm not 100% sure this is kosher.

Usage as primary storage adapter:

```ruby
pool = ConnectionPool.new(size: 5, timeout: 5) { Redis.new }
adapter = Flipper::Adapters::ConnectionPool.new(pool) do |client|
  Flipper::Adapters::Redis.new(client)
end

# Read about the `config.adapter` problem below
Flipper.configure do |config|
  config.adapter { adapter }
end
```

Usage with cache adapter:

```ruby
pool = ConnectionPool.new(size: 5, timeout: 5) { Redis.new }
storage = Flipper::Adapters::ActiveRecord.new
adapter = Flipper::Adapters::ConnectionPool.new(pool) do |client|
  Flipper::Adapters::RedisCache.new(storage, client)
end

# Read about the `config.adapter` problem below
Flipper.configure do |config|
  config.adapter { adapter }
end
```

### The `config.adapter` problem

Currently, Flipper returns a new adapter instance (it calls the `config.adapter` block) for each thread. This is to guard against some adapters not being thread safe. Initializing this adapter inside `config.adapter` block would _probably_ work fine, but it would result in a separate adapter cache for each thread (n threads * x pool size).

I'm thinking we should add `threadsafe?` to the adapter API and change Flipper to reuse adapter instances of threadsafe adapters.

cc @cymen