### PR TITLE
Enable telemetry by default

### DIFF
--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -174,7 +174,7 @@ module Flipper
       end
 
       def setup_log(options)
-        set_option :logging_enabled, options, default: true, typecast: :boolean
+        set_option :logging_enabled, options, default: false, typecast: :boolean
         set_option :logger, options, from_env: false, default: -> {
           if logging_enabled
             Logger.new(STDOUT)

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -214,8 +214,7 @@ module Flipper
           Telemetry.instance_for(self)
         }
 
-        # This is alpha. Don't use this unless you are me. And you are not me.
-        set_option :telemetry_enabled, options, default: false, typecast: :boolean
+        set_option :telemetry_enabled, options, default: true, typecast: :boolean
         instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
         @instrumenter = if telemetry_enabled
           Telemetry::Instrumenter.new(self, instrumenter)

--- a/lib/flipper/cloud/telemetry/instrumenter.rb
+++ b/lib/flipper/cloud/telemetry/instrumenter.rb
@@ -3,9 +3,11 @@ require "delegate"
 module Flipper
   module Cloud
     class Telemetry
-      class Instrumenter < SimpleDelegator
+      class Instrumenter
+        attr_reader :instrumenter
+
         def initialize(cloud_configuration, instrumenter)
-          super instrumenter
+          @instrumenter = instrumenter
           @cloud_configuration = cloud_configuration
         end
 
@@ -13,12 +15,6 @@ module Flipper
           return_value = instrumenter.instrument(name, payload, &block)
           @cloud_configuration.telemetry.record(name, payload)
           return_value
-        end
-
-        private
-
-        def instrumenter
-          __getobj__
         end
       end
     end

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Flipper::Cloud::Configuration do
   it "can set instrumenter" do
     instrumenter = Object.new
     instance = described_class.new(required_options.merge(instrumenter: instrumenter))
-    expect(instance.instrumenter).to be(instrumenter)
+    expect(instance.instrumenter).to be_a(Flipper::Cloud::Telemetry::Instrumenter)
+    expect(instance.instrumenter.instrumenter).to be(instrumenter)
   end
 
   it "can set read_timeout" do

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Flipper::Cloud do
       expect(client.uri.host).to eq('www.flippercloud.io')
       expect(client.uri.path).to eq('/adapter')
       expect(client.headers["flipper-cloud-token"]).to eq(token)
-      expect(@instance.instrumenter).to be(Flipper::Instrumenters::Noop)
+      expect(@instance.instrumenter).to be_a(Flipper::Cloud::Telemetry::Instrumenter)
+      expect(@instance.instrumenter.instrumenter).to be(Flipper::Instrumenters::Noop)
     end
   end
 
@@ -62,7 +63,8 @@ RSpec.describe Flipper::Cloud do
   it 'can set instrumenter' do
     instrumenter = Flipper::Instrumenters::Memory.new
     instance = described_class.new(token: 'asdf', instrumenter: instrumenter)
-    expect(instance.instrumenter).to be(instrumenter)
+    expect(instance.instrumenter).to be_a(Flipper::Cloud::Telemetry::Instrumenter)
+    expect(instance.instrumenter.instrumenter).to be(instrumenter)
   end
 
   it 'allows wrapping adapter with another adapter like the instrumenter' do

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -236,7 +236,8 @@ RSpec.describe Flipper::Engine do
       application.initialize!
 
       expect(Flipper.instance).to be_a(Flipper::Cloud::DSL)
-      expect(Flipper.instance.instrumenter).to be(ActiveSupport::Notifications)
+      expect(Flipper.instance.instrumenter).to be_a(Flipper::Cloud::Telemetry::Instrumenter)
+      expect(Flipper.instance.instrumenter.instrumenter).to be(ActiveSupport::Notifications)
     end
 
     context "with CLOUD_SYNC_SECRET" do


### PR DESCRIPTION
This turns on telemetry by default. 

Also, this turns off telemetry logging by default so its not annoying to people.