### PR TITLE
Micro optimization for `#features` on ActiveRecord adapter

### DIFF
--- a/benchmark/active_record_adapter_ips.rb
+++ b/benchmark/active_record_adapter_ips.rb
@@ -6,10 +6,13 @@ require 'benchmark/ips'
 
 flipper = Flipper.new(Flipper::Adapters::ActiveRecord.new)
 
-2000.times do |i|
-  flipper.enable_actor :foo, Flipper::Actor.new("User;#{i}")
+10.times do |n|
+  2000.times do |i|
+    flipper.enable_actor 'feature' + n.to_s, Flipper::Actor.new("User;#{i}")
+  end
 end
 
 Benchmark.ips do |x|
   x.report("get_all") { flipper.preload_all }
+  x.report("features") { flipper.features }
 end

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -59,7 +59,7 @@ module Flipper
 
       # Public: The set of known features.
       def features
-        with_connection(@feature_class) { @feature_class.all.map(&:key).to_set }
+        with_connection(@feature_class) { @feature_class.distinct.pluck(:key).to_set }
       end
 
       # Public: Adds a feature to the set of known features.
@@ -68,9 +68,9 @@ module Flipper
           # race condition, but add is only used by enable/disable which happen
           # super rarely, so it shouldn't matter in practice
           @feature_class.transaction do
-            unless @feature_class.where(key: feature.key).first
+            unless @feature_class.where(key: feature.key).exists?
               begin
-                @feature_class.create! { |f| f.key = feature.key }
+                @feature_class.create!(key: feature.key)
               rescue ::ActiveRecord::RecordNotUnique
               end
             end


### PR DESCRIPTION
I noticed `#features` was calling `Gate.all.map(&:key).to_set` to get the list of features, which will pull a lot of data over the wire to get the list of features. This replaces it with `Gate.distinct.pluck(:key).to_set`.  Thankfully, `#features` is not used in our hot code path internally (`get_all` with memoization is used when checking `#enabled?`), but this could have some impact for those with large actor sets.

```
$ ruby benchmarks/active_record_ips.rb

# Before:
            features      6.453k (± 8.3%) i/s -     32.604k in   5.088062s
# After:
            features     10.130k (± 8.6%) i/s -     50.661k in   5.038290s
```

This benchmark uses an sqlite in-memory database, so the results should be even more dramatic over a network connection.
