### PR TITLE
Add base class for wrapping another adapter

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -174,6 +174,7 @@ end
 
 require 'flipper/actor'
 require 'flipper/adapter'
+require 'flipper/adapters/wrapper'
 require 'flipper/adapters/memoizable'
 require 'flipper/adapters/memory'
 require 'flipper/adapters/strict'

--- a/lib/flipper/adapters/operation_logger.rb
+++ b/lib/flipper/adapters/operation_logger.rb
@@ -5,106 +5,25 @@ module Flipper
     # Public: Adapter that wraps another adapter and stores the operations.
     #
     # Useful in tests to verify calls and such. Never use outside of testing.
-    class OperationLogger
-      include Flipper::Adapter
+    class OperationLogger < Wrapper
 
       class Operation
-        attr_reader :type, :args
+        attr_reader :type, :args, :kwargs
 
-        def initialize(type, args)
+        def initialize(type, args, kwargs = {})
           @type = type
           @args = args
+          @kwargs = kwargs
         end
       end
-
-      OperationTypes = [
-        :import,
-        :export,
-        :features,
-        :add,
-        :remove,
-        :clear,
-        :get,
-        :get_multi,
-        :get_all,
-        :enable,
-        :disable,
-      ].freeze
 
       # Internal: An array of the operations that have happened.
       attr_reader :operations
 
       # Public
       def initialize(adapter, operations = nil)
-        @adapter = adapter
+        super(adapter)
         @operations = operations || []
-      end
-
-      # Public: The set of known features.
-      def features
-        @operations << Operation.new(:features, [])
-        @adapter.features
-      end
-
-      # Public: Adds a feature to the set of known features.
-      def add(feature)
-        @operations << Operation.new(:add, [feature])
-        @adapter.add(feature)
-      end
-
-      # Public: Removes a feature from the set of known features and clears
-      # all the values for the feature.
-      def remove(feature)
-        @operations << Operation.new(:remove, [feature])
-        @adapter.remove(feature)
-      end
-
-      # Public: Clears all the gate values for a feature.
-      def clear(feature)
-        @operations << Operation.new(:clear, [feature])
-        @adapter.clear(feature)
-      end
-
-      # Public
-      def get(feature)
-        @operations << Operation.new(:get, [feature])
-        @adapter.get(feature)
-      end
-
-      # Public
-      def get_multi(features)
-        @operations << Operation.new(:get_multi, [features])
-        @adapter.get_multi(features)
-      end
-
-      # Public
-      def get_all
-        @operations << Operation.new(:get_all, [])
-        @adapter.get_all
-      end
-
-      # Public
-      def enable(feature, gate, thing)
-        @operations << Operation.new(:enable, [feature, gate, thing])
-        @adapter.enable(feature, gate, thing)
-      end
-
-      # Public
-      def disable(feature, gate, thing)
-        @operations << Operation.new(:disable, [feature, gate, thing])
-        @adapter.disable(feature, gate, thing)
-      end
-
-      # Public
-      def import(source)
-        @operations << Operation.new(:import, [source])
-        @adapter.import(source)
-      end
-
-      # Public
-      def export(format: :json, version: 1)
-        @operations << Operation.new(:export, [format, version])
-        @adapter.export(format: format, version: version)
       end
 
       # Public: Count the number of times a certain operation happened.
@@ -130,6 +49,13 @@ module Flipper
       def inspect
         inspect_id = ::Kernel::format "%x", (object_id * 2)
         %(#<#{self.class}:0x#{inspect_id} @name=#{name.inspect}, @operations=#{@operations.inspect}, @adapter=#{@adapter.inspect}>)
+      end
+
+      private
+
+      def wrap(method, *args, **kwargs, &block)
+        @operations << Operation.new(method, args, kwargs)
+        block.call
       end
     end
   end

--- a/lib/flipper/adapters/read_only.rb
+++ b/lib/flipper/adapters/read_only.rb
@@ -3,8 +3,8 @@ require 'flipper'
 module Flipper
   module Adapters
     # Public: Adapter that wraps another adapter and raises for any writes.
-    class ReadOnly
-      include ::Flipper::Adapter
+    class ReadOnly < Wrapper
+      WriteMethods = %i[add remove clear enable disable]
 
       class WriteAttempted < Error
         def initialize(message = nil)
@@ -12,49 +12,16 @@ module Flipper
         end
       end
 
-      # Public
-      def initialize(adapter)
-        @adapter = adapter
-      end
-
-      def features
-        @adapter.features
-      end
-
       def read_only?
         true
       end
 
-      def get(feature)
-        @adapter.get(feature)
-      end
+      private
 
-      def get_multi(features)
-        @adapter.get_multi(features)
-      end
+      def wrap(method, *args, **kwargs)
+        raise WriteAttempted if WriteMethods.include?(method)
 
-      def get_all
-        @adapter.get_all
-      end
-
-      def add(_feature)
-        raise WriteAttempted
-      end
-
-      def remove(_feature)
-        raise WriteAttempted
-      end
-
-      def clear(_feature)
-        raise WriteAttempted
-      end
-
-      def enable(_feature, _gate, _thing)
-        raise WriteAttempted
-      end
-
-      def disable(_feature, _gate, _thing)
-        raise WriteAttempted
+        yield
       end
     end
   end

--- a/lib/flipper/adapters/strict.rb
+++ b/lib/flipper/adapters/strict.rb
@@ -1,10 +1,8 @@
 module Flipper
   module Adapters
     # An adapter that ensures a feature exists before checking it.
-    class Strict
-      extend Forwardable
-      include ::Flipper::Adapter
-      attr_reader :name, :adapter, :handler
+    class Strict < Wrapper
+      attr_reader :handler
 
       class NotFound < ::Flipper::Error
         def initialize(name)
@@ -12,22 +10,19 @@ module Flipper
         end
       end
 
-      def_delegators :@adapter, :features, :get_all, :add, :remove, :clear, :enable, :disable
-
       def initialize(adapter, handler = nil, &block)
-        @name = :strict
-        @adapter = adapter
+        super(adapter)
         @handler = block || handler
       end
 
       def get(feature)
         assert_feature_exists(feature)
-        @adapter.get(feature)
+        super
       end
 
       def get_multi(features)
         features.each { |feature| assert_feature_exists(feature) }
-        @adapter.get_multi(features)
+        super
       end
 
       private

--- a/lib/flipper/adapters/wrapper.rb
+++ b/lib/flipper/adapters/wrapper.rb
@@ -1,0 +1,42 @@
+module Flipper
+  module Adapters
+    # A base class for any adapter that wraps another adapter. By default, all methods
+    # delegate to the wrapped adapter. Implement `#wrap` to customize the behavior of
+    # all delegated methods, or override individual methods as needed.
+    class Wrapper
+      include Flipper::Adapter
+
+      Methods = [
+        :import,
+        :export,
+        :features,
+        :add,
+        :remove,
+        :clear,
+        :get,
+        :get_multi,
+        :get_all,
+        :enable,
+        :disable,
+      ].freeze
+
+      attr_reader :adapter
+
+      def initialize(adapter)
+        @adapter = adapter
+      end
+
+      Methods.each do |method|
+        define_method(method) do |*args, **kwargs|
+          wrap(method, *args, **kwargs) { @adapter.public_send(method, *args, **kwargs) }
+        end
+      end
+
+      # Override this method to customize the behavior of all delegated methods, and just yield to
+      # the block to call the wrapped adapter.
+      def wrap(method, *args, **kwargs, &block)
+        block.call
+      end
+    end
+  end
+end

--- a/lib/flipper/adapters/wrapper.rb
+++ b/lib/flipper/adapters/wrapper.rb
@@ -27,15 +27,27 @@ module Flipper
       end
 
       Methods.each do |method|
-        define_method(method) do |*args, **kwargs|
-          wrap(method, *args, **kwargs) { @adapter.public_send(method, *args, **kwargs) }
+        if RUBY_VERSION >= '3.0'
+          define_method(method) do |*args, **kwargs|
+            wrap(method, *args, **kwargs) { @adapter.public_send(method, *args, **kwargs) }
+          end
+        else
+          define_method(method) do |*args|
+            wrap(method, *args) { @adapter.public_send(method, *args) }
+          end
         end
       end
 
       # Override this method to customize the behavior of all delegated methods, and just yield to
       # the block to call the wrapped adapter.
-      def wrap(method, *args, **kwargs, &block)
-        block.call
+      if RUBY_VERSION >= '3.0'
+        def wrap(method, *args, **kwargs, &block)
+          block.call
+        end
+      else
+        def wrap(method, *args, &block)
+          block.call
+        end
       end
     end
   end


### PR DESCRIPTION
This adds `Flipper::Adapters::Wrapper`, which can be used as a base class for an adapter that just wraps another adapter. By default, all methods delegate to the wrapped adapter. Implement `#wrap` to customize the behavior of all delegated methods, or override individual methods as needed.

```ruby
class MyNewAdapter < Flipper::Adapters::Wrapper
  # Override a speciific method to change its behavior
  def enable(feature, gate, resource)
    # …
  end

  # Override this method to customize the behavior of all delegated methods, and just yield to
  # the block to call the wrapped adapter.
  def wrap(method, *args, **kwargs)
     if some_condition?(method)
       yield # call original adapter method
    else
       # do something else
    end
  end
end
```

And then you can configure Flipper to use the new adapter:

```
Flipper.configure do |config|
  config.use MyNewAdapter
end
```