### PR TITLE
Add telemetry shutdown header

### DIFF
--- a/lib/flipper/cloud/telemetry.rb
+++ b/lib/flipper/cloud/telemetry.rb
@@ -160,8 +160,16 @@ module Flipper
         # thus may have a telemetry-interval header for us to respect.
         response ||= error.response if error && error.respond_to?(:response)
 
-        if response && interval = response["telemetry-interval"]
-          self.interval = interval.to_f
+        if response
+          if Flipper::Typecast.to_boolean(response["telemetry-shutdown"])
+            debug "action=telemetry_shutdown message=The server has requested that telemetry be shut down."
+            stop
+            return
+          end
+
+          if interval = response["telemetry-interval"]
+            self.interval = interval.to_f
+          end
         end
       rescue => error
         error "action=post_to_cloud error=#{error.inspect}"

--- a/spec/flipper/cloud/telemetry_spec.rb
+++ b/spec/flipper/cloud/telemetry_spec.rb
@@ -42,6 +42,52 @@ RSpec.describe Flipper::Cloud::Telemetry do
     expect(stub).to have_been_requested
   end
 
+  it "phones home and requests shutdown if telemetry-shutdown header is true" do
+    stub = stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
+      to_return(status: 404, body: "{}", headers: {"telemetry-shutdown" => "true"})
+
+    output = StringIO.new
+    cloud_configuration = Flipper::Cloud::Configuration.new(
+      token: "test",
+      logger: Logger.new(output),
+      logging_enabled: true,
+    )
+
+    # Record some telemetry and stop the threads so we submit a response.
+    telemetry = described_class.new(cloud_configuration)
+    telemetry.record(Flipper::Feature::InstrumentationName, {
+      operation: :enabled?,
+      feature_name: :foo,
+      result: true,
+    })
+    telemetry.stop
+    expect(stub).to have_been_requested
+    expect(output.string).to match(/action=telemetry_shutdown message=The server has requested that telemetry be shut down./)
+  end
+
+  it "phones home and does not shutdown if telemetry shutdown header is missing" do
+    stub = stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
+      to_return(status: 404, body: "{}", headers: {})
+
+    output = StringIO.new
+    cloud_configuration = Flipper::Cloud::Configuration.new(
+      token: "test",
+      logger: Logger.new(output),
+      logging_enabled: true,
+    )
+
+    # Record some telemetry and stop the threads so we submit a response.
+    telemetry = described_class.new(cloud_configuration)
+    telemetry.record(Flipper::Feature::InstrumentationName, {
+      operation: :enabled?,
+      feature_name: :foo,
+      result: true,
+    })
+    telemetry.stop
+    expect(stub).to have_been_requested
+    expect(output.string).not_to match(/action=telemetry_shutdown message=The server has requested that telemetry be shut down./)
+  end
+
   it "can update telemetry interval from error" do
     stub = stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
       to_return(status: 500, body: "{}", headers: {"telemetry-interval" => "120"})

--- a/spec/flipper/cloud/telemetry_spec.rb
+++ b/spec/flipper/cloud/telemetry_spec.rb
@@ -2,6 +2,12 @@ require 'flipper/cloud/telemetry'
 require 'flipper/cloud/configuration'
 
 RSpec.describe Flipper::Cloud::Telemetry do
+  before do
+    # Stub polling for features.
+    stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
+      to_return(status: 200, body: "{}")
+  end
+
   it "phones home and does not update telemetry interval if missing" do
     stub = stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
       to_return(status: 200, body: "{}")


### PR DESCRIPTION
So we can turn off however we like regardless of status code from the server side.