### PR TITLE
Refactor shared adapter test

### DIFF
--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -108,19 +108,19 @@ RSpec.shared_examples_for 'a flipper adapter' do
     actor22 = Flipper::Actor.new('22')
     actor_asdf = Flipper::Actor.new('asdf')
 
-    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor22))).to eq(true)
-    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor_asdf))).to eq(true)
+    expect(feature.enable(actor22)).to be(true)
+    expect(feature.enable(actor_asdf)).to be(true)
 
-    result = subject.get(feature)
-    expect(result[:actors]).to eq(Set['22', 'asdf'])
+    expect(feature).to be_enabled(actor22)
+    expect(feature).to be_enabled(actor_asdf)
 
-    expect(subject.disable(feature, actor_gate, Flipper::Types::Actor.new(actor22))).to eq(true)
-    result = subject.get(feature)
-    expect(result[:actors]).to eq(Set['asdf'])
+    expect(feature.disable(actor22)).to be(true)
+    expect(feature).not_to be_enabled(actor22)
+    expect(feature).to be_enabled(actor_asdf)
 
-    expect(subject.disable(feature, actor_gate, Flipper::Types::Actor.new(actor_asdf))).to eq(true)
-    result = subject.get(feature)
-    expect(result[:actors]).to eq(Set.new)
+    expect(feature.disable(actor_asdf)).to eq(true)
+    expect(feature).not_to be_enabled(actor22)
+    expect(feature).not_to be_enabled(actor_asdf)
   end
 
   it 'can enable, disable and get value for percentage of actors gate' do
@@ -182,9 +182,10 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'converts the actor value to a string' do
-    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(Flipper::Actor.new(22)))).to eq(true)
-    result = subject.get(feature)
-    expect(result[:actors]).to eq(Set['22'])
+    actor = Flipper::Actor.new(22)
+    expect(feature).not_to be_enabled(actor)
+    feature.enable_actor actor
+    expect(feature).to be_enabled(actor)
   end
 
   it 'converts group value to a string' do
@@ -295,9 +296,9 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'can double enable an actor without error' do
     actor = Flipper::Actor.new('Flipper::Actor;22')
-    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor))).to eq(true)
-    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor))).to eq(true)
-    expect(subject.get(feature).fetch(:actors)).to eq(Set['Flipper::Actor;22'])
+    expect(feature.enable(actor)).to be(true)
+    expect(feature.enable(actor)).to be(true)
+    expect(feature).to be_enabled(actor)
   end
 
   it 'can double enable a group without error' do

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -104,19 +104,19 @@ module Flipper
         actor22 = Flipper::Actor.new('22')
         actor_asdf = Flipper::Actor.new('asdf')
 
-        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor22))
-        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor_asdf))
+        assert_equal true, @feature.enable(actor22)
+        assert_equal true, @feature.enable(actor_asdf)
 
-        result = @adapter.get(@feature)
-        assert_equal Set['22', 'asdf'], result[:actors]
+        assert @feature.enabled?(actor22)
+        assert @feature.enabled?(actor_asdf)
 
-        assert true, @adapter.disable(@feature, @actor_gate, Flipper::Types::Actor.new(actor22))
-        result = @adapter.get(@feature)
-        assert_equal Set['asdf'], result[:actors]
+        assert_equal true, @feature.disable(actor22)
+        refute @feature.enabled?(actor22)
+        assert @feature.enabled?(actor_asdf)
 
-        assert_equal true, @adapter.disable(@feature, @actor_gate, Flipper::Types::Actor.new(actor_asdf))
-        result = @adapter.get(@feature)
-        assert_equal Set.new, result[:actors]
+        assert_equal true, @feature.disable(actor_asdf)
+        refute @feature.enabled?(actor22)
+        refute @feature.enabled?(actor_asdf)
       end
 
       def test_can_enable_disable_get_value_for_percentage_of_actors_gate
@@ -178,10 +178,10 @@ module Flipper
       end
 
       def test_converts_the_actor_value_to_a_string
-        assert_equal true,
-                     @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(Flipper::Actor.new(22)))
-        result = @adapter.get(@feature)
-        assert_equal Set['22'], result[:actors]
+        actor = Flipper::Actor.new(22)
+        refute @feature.enabled?(actor)
+        @feature.enable_actor actor
+        assert @feature.enabled?(actor)
       end
 
       def test_converts_group_value_to_a_string
@@ -292,9 +292,9 @@ module Flipper
 
       def test_can_double_enable_an_actor_without_error
         actor = Flipper::Actor.new('Flipper::Actor;22')
-        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor))
-        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor))
-        assert_equal Set['Flipper::Actor;22'], @adapter.get(@feature).fetch(:actors)
+        assert_equal true, @feature.enable(actor)
+        assert_equal true, @feature.enable(actor)
+        assert @feature.enabled?(actor)
       end
 
       def test_can_double_enable_a_group_without_error


### PR DESCRIPTION
This refactors some of the adapter tests related to actors to use the feature interface instead of directly inspecting the adapters data. This change is needed for some work I'm doing to support large actor sets.