### PR TITLE
Add ActiveRecord validations to mirror table NOT NULL constraint

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -21,6 +21,8 @@ module Flipper
         ].join
 
         has_many :gates, foreign_key: "feature_key", primary_key: "key"
+
+        validates :key, presence: true
       end
 
       # Private: Do not use outside of this adapter.
@@ -30,6 +32,9 @@ module Flipper
           "flipper_gates",
           Model.table_name_suffix,
         ].join
+
+        validates :feature_key, presence: true
+        validates :key, presence: true
       end
 
       VALUE_TO_TEXT_WARNING = <<-EOS


### PR DESCRIPTION
This is a minor thing in my opinion.

I use `active_record_doctor` to identify potential database issues or risks.

When I run `$ bin/rake active_record_doctor` after I added `flipper-active_record`, I received the following recommendations:

```
add a `presence` validator to Flipper::Adapters::ActiveRecord::Gate.feature_key - it's NOT NULL but lacks a validator
add a `presence` validator to Flipper::Adapters::ActiveRecord::Gate.key - it's NOT NULL but lacks a validator
add a `presence` validator to Flipper::Adapters::ActiveRecord::Feature.key - it's NOT NULL but lacks a validator
```

Ref. <https://github.com/gregnavis/active_record_doctor?tab=readme-ov-file#detecting-missing-presence-validations>

This pull request adds these validators.