### PR TITLE
Remove redundant deletion of feature gate in Flipper::Adapters::ActiveRecord#set.

### DIFF
--- a/lib/flipper/adapter_builder.rb
+++ b/lib/flipper/adapter_builder.rb
@@ -3,7 +3,7 @@ module Flipper
   #
   #   adapter = Flipper::AdapterBuilder.new do
   #     use Flipper::Adapters::Strict
-  #     use Flipper::Adapters::Memoizer
+  #     use Flipper::Adapters::Memoizable
   #     store Flipper::Adapters::Memory
   #   end.to_adapter
   #

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -221,7 +221,6 @@ module Flipper
           @gate_class.transaction do
             clear(feature) if clear_feature
             delete(feature, gate)
-            @gate_class.where(feature_key: feature.key, key: gate.key).destroy_all
             begin
               @gate_class.create! do |g|
                 g.feature_key = feature.key


### PR DESCRIPTION
Hello, I noticed the duplicate deletions in `Flipper::Adapters::ActiveRecord#set`
The `Flipper::Adapters::ActiveRecord#delete` already does the same `destroy_all`.