### PR TITLE
Maintain Rails 4.2 compatibility

### DIFF
--- a/lib/flipper/engine.rb
+++ b/lib/flipper/engine.rb
@@ -39,8 +39,10 @@ module Flipper
 
     initializer "flipper.default", before: :load_config_initializers do |app|
       # Load cloud secrets from Rails credentials
-      ENV["FLIPPER_CLOUD_TOKEN"] ||= app.credentials.dig(:flipper, :cloud_token)
-      ENV["FLIPPER_CLOUD_SYNC_SECRET"] ||= app.credentials.dig(:flipper, :cloud_sync_secret)
+      if defined?(app.credentials)
+        ENV["FLIPPER_CLOUD_TOKEN"] ||= app.credentials.dig(:flipper, :cloud_token)
+        ENV["FLIPPER_CLOUD_SYNC_SECRET"] ||= app.credentials.dig(:flipper, :cloud_sync_secret)
+      end
 
       require 'flipper/cloud' if cloud?
 


### PR DESCRIPTION
This PR patches the active record adapter to work with 4.2. The two issues were originally noticed by @clinejj

https://github.com/flippercloud/flipper/issues/857
https://github.com/flippercloud/flipper/issues/858

Getting errors with some tests needing sqllite 1.4.4 though:

Update:
Need to fix tests in rails 5.2, 6, and 6.1. Appears to be a setup issue since `Rails::VERSION::MAJOR` is definitely still  defined in Rails 6.

```
Loading staging environment (Rails 6.0.0)
irb(main):001:0> Rails::VERSION::MAJOR
=> 6
```

```
SQLITE3_VERSION='2.0.1' bundle exec rake

Failures:

  1) Flipper::Model::ActiveRecord flipper_id returns class name and id
     Failure/Error: ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')

     LoadError:
       Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-darwin. Make sure all dependencies are added to Gemfile.
     # ./spec/flipper/model/active_record_spec.rb:9:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Gem::LoadError:
     #   can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-darwin. Make sure all dependencies are added to Gemfile.
     #   ./spec/flipper/model/active_record_spec.rb:9:in `block (2 levels) in <top (required)>'

  2) Flipper::Model::ActiveRecord flipper_id uses base class name
     Failure/Error: ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')

     LoadError:
       Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-darwin. Make sure all dependencies are added to Gemfile.
     # ./spec/flipper/model/active_record_spec.rb:9:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Gem::LoadError:
     #   can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-darwin. Make sure all dependencies are added to Gemfile.
     #   ./spec/flipper/model/active_record_spec.rb:9:in `block (2 levels) in <top (required)>'

  3) Flipper::Model::ActiveRecord flipper_properties includes all attributes
     Failure/Error: ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')

     LoadError:
       Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-darwin. Make sure all dependencies are added to Gemfile.
     # ./spec/flipper/model/active_record_spec.rb:9:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Gem::LoadError:
     #   can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-darwin. Make sure all dependencies are added to Gemfile.
     #   ./spec/flipper/model/active_record_spec.rb:9:in `block (2 levels) in <top (required)>'

Finished in 30.49 seconds (files took 5.89 seconds to load)
2622 examples, 3 failures, 131 pending

```