### PR TITLE
Address soft deprecation of `ActiveRecord::Base.connection`

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -130,14 +130,14 @@ module Flipper
       end
 
       def get_all
-        with_connection(@feature_class) do
+        with_connection(@feature_class) do |connection|
           # query the gates from the db in a single query
           features = ::Arel::Table.new(@feature_class.table_name.to_sym)
           gates = ::Arel::Table.new(@gate_class.table_name.to_sym)
           rows_query = features.join(gates, ::Arel::Nodes::OuterJoin)
             .on(features[:key].eq(gates[:feature_key]))
             .project(features[:key].as('feature_key'), gates[:key], gates[:value])
-          gates = @feature_class.connection.select_rows(rows_query)
+          gates = connection.select_rows(rows_query)
 
           # group the gates by feature key
           grouped_gates = gates.inject({}) do |hash, (feature_key, key, value)|


### PR DESCRIPTION
Related: https://github.com/flippercloud/flipper/pull/705

Refs:
- https://github.com/rails/rails/blob/b752c38e81a310c1aaca78c7cdd1784009ea189a/activerecord/lib/active_record/connection_handling.rb#L259
- https://github.com/rails/rails/blob/b752c38e81a310c1aaca78c7cdd1784009ea189a/activerecord/lib/active_record/connection_handling.rb#L293-L294

This will be soft deprecated in Rails 7.2.

The reason for this change is twofold.

1. We're running on Rails Edge with `active_record.permanent_connection_checkout = :deprecated` and this call to `#connection` was logged as a violation. Our goal is to configure this with `:disallowed` some day. Even if this needed to be a permanent checkout, `connection` should ideally be swapped with `lease_connection` (this would require a specific check to ensure the Rails dependency is >= 7.2).

2. Despite being called inside a `with_connection` block, this call actually leases a connection and doesn't return it back to the pool until the end of the request, which seems to have been intention behind #705. This ensures we use the connection temporarily leased by `with_connection`.