### PR TITLE
Load extra JS scripts into flipper-ui

### DIFF
--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -77,6 +77,11 @@ module Flipper
       # Default is false.
       attr_accessor :confirm_disable
 
+      # Public: An array of scripts to include in the UI. Each script should be
+      # a hash with a `:src` key and optionally a `:integrity` key. Example:
+      # config.scripts << { src: "https://example.com/script.js", integrity: "sha384-abc123" }
+      attr_accessor :scripts
+
       VALID_BANNER_CLASS_VALUES = %w(
         danger
         dark
@@ -111,6 +116,7 @@ module Flipper
           { title: "Features", href: "features" },
           { title: "Settings", href: "settings" },
         ]
+        @scripts = []
       end
 
       def using_descriptions?

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -84,5 +84,16 @@
     <script src="<%= script_name + bootstrap_js[:src] %>" integrity="<%= bootstrap_js[:hash] %>" crossorigin="anonymous"></script>
     <script src="<%= script_name %>/js/application.js?v=<%= Flipper::VERSION %>"></script>
     <script src="<%= script_name %>/js/version.js?v=<%= Flipper::VERSION %>"></script>
+    <% unless Flipper::UI.configuration.scripts.empty? %>
+      <% Flipper::UI.configuration.scripts.each do |script| %>
+        <script
+          src="<%= script[:src] %>"
+          <% if script[:integrity].present? %>
+            integrity="<%= script[:integrity] %>"
+          <% end %>
+          crossorigin="anonymous">
+        </script>
+      <% end %>
+    <% end %>
   </body>
 </html>

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -182,4 +182,15 @@ RSpec.describe Flipper::UI::Configuration do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe "#scripts" do
+    it "has default value" do
+      expect(configuration.scripts).to eq([])
+    end
+
+    it "can be updated" do
+      configuration.scripts << { src: "https://example.com/script.js", integrity: "sha384-abc123" }
+      expect(configuration.scripts).to eq([{ src: "https://example.com/script.js", integrity: "sha384-abc123" }])
+    end
+  end
 end


### PR DESCRIPTION
## Adds the ability to load extra JS scripts into flipper UI.

Added a new field `scripts` to `lib/flipper/ui/configuration.rb` so it allows to load scripts into the layout of flipper-ui.

### Usage:
```
Flipper::UI.configure do |config|
  config.scripts << { src: "https://example.com/script.js" }
end
```

