### PR TITLE
Active record poisoned transaction with postgres

### DIFF
--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
           flipper.preload([:foo])
         end
 
+        it 'should not poision wrapping transactions' do
+          flipper = Flipper.new(subject)
+
+          actor = Struct.new(:flipper_id).new('flipper-id-123')
+          flipper.enable_actor(:foo, actor)
+
+          ActiveRecord::Base.transaction do
+            flipper.enable_actor(:foo, actor)
+            expect(Flipper::Adapters::ActiveRecord::Gate.count).to eq 1
+          end
+        end
+
         context "ActiveRecord connection_pool" do
           before do
             ActiveRecord::Base.connection_handler.clear_active_connections!

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
           flipper.preload([:foo])
         end
 
-        it 'should not poision wrapping transactions' do
+        it 'should not poison wrapping transactions' do
           flipper = Flipper.new(subject)
 
           actor = Struct.new(:flipper_id).new('flipper-id-123')

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -83,7 +83,9 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
 
           ActiveRecord::Base.transaction do
             flipper.enable_actor(:foo, actor)
-            expect(Flipper::Adapters::ActiveRecord::Gate.count).to eq 1
+            # any read on the next line is fine, just need to ensure that
+            # poisoned transaction isn't raised
+            expect(Flipper::Adapters::ActiveRecord::Gate.count).to eq(1)
           end
         end
 

--- a/spec/flipper/adapters/strict_spec.rb
+++ b/spec/flipper/adapters/strict_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe Flipper::Adapters::Strict do
 
     context "#get" do
       it "raises an error for unknown feature" do
-        expect(silence { subject.get(feature) }).to match(/Could not find feature "unknown"/)
+        expect(capture_output { subject.get(feature) }).to match(/Could not find feature "unknown"/)
       end
     end
 
     context "#get_multi" do
       it "raises an error for unknown feature" do
-        expect(silence { subject.get_multi([feature]) }).to match(/Could not find feature "unknown"/)
+        expect(capture_output { subject.get_multi([feature]) }).to match(/Could not find feature "unknown"/)
       end
     end
   end

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Flipper::Engine do
 
   let(:config) { application.config.flipper }
 
-  subject { application.initialize! }
+  subject { SpecHelpers.silence { application.initialize! } }
 
   shared_examples 'config.strict' do
     let(:adapter) { Flipper.adapter.adapter }

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Flipper::Engine do
     it "initializes cloud configuration" do
       stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
 
-      application.initialize!
+      silence { application.initialize! }
 
       expect(Flipper.instance).to be_a(Flipper::Cloud::DSL)
       expect(Flipper.instance.instrumenter).to be_a(Flipper::Cloud::Telemetry::Instrumenter)
@@ -263,7 +263,7 @@ RSpec.describe Flipper::Engine do
       }
 
       it "configures webhook app" do
-        application.initialize!
+        silence { application.initialize! }
 
         stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").with({
           headers: { "flipper-cloud-token" => ENV["FLIPPER_CLOUD_TOKEN"] },
@@ -278,7 +278,7 @@ RSpec.describe Flipper::Engine do
 
     context "without CLOUD_SYNC_SECRET" do
       it "does not configure webhook app" do
-        application.initialize!
+        silence { application.initialize! }
 
         post "/_flipper"
         expect(last_response.status).to eq(404)
@@ -288,7 +288,7 @@ RSpec.describe Flipper::Engine do
     context "without FLIPPER_CLOUD_TOKEN" do
       it "gracefully skips configuring webhook app" do
         ENV["FLIPPER_CLOUD_TOKEN"] = nil
-        application.initialize!
+        silence { application.initialize! }
         expect(Flipper.instance).to be_a(Flipper::DSL)
 
         post "/_flipper"
@@ -324,7 +324,7 @@ RSpec.describe Flipper::Engine do
     end
 
     it "enables cloud" do
-      application.initialize!
+      silence { application.initialize! }
       expect(ENV["FLIPPER_CLOUD_TOKEN"]).to eq("credentials-token")
       expect(ENV["FLIPPER_CLOUD_SYNC_SECRET"]).to eq("credentials-secret")
       expect(Flipper.instance).to be_a(Flipper::Cloud::DSL)
@@ -339,7 +339,7 @@ RSpec.describe Flipper::Engine do
 
   describe "config.actor_limit" do
     let(:adapter) do
-      application.initialize!
+      silence { application.initialize! }
       Flipper.adapter.adapter.adapter
     end
 

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
     end
 
     def get(uri, params = {}, env = {}, &block)
-      silence { super(uri, params, env, &block) }
+      capture_output { super(uri, params, env, &block) }
     end
 
     include_examples 'flipper middleware'

--- a/spec/support/fail_on_output.rb
+++ b/spec/support/fail_on_output.rb
@@ -1,7 +1,7 @@
 if ENV["CI"] || ENV["FAIL_ON_OUTPUT"]
   RSpec.configure do |config|
     config.around do |example|
-      output = silence { example.run }
+      output = capture_output { example.run }
       fail "Use `silence { }` to avoid printing to STDOUT/STDERR\n#{output}" unless output.empty?
     end
   end

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -79,11 +79,22 @@ module SpecHelpers
     original_stdout = $stdout
 
     # Redirect stderr and stdout
-    output = $stderr = $stdout = StringIO.new
+    $stderr = $stdout = StringIO.new
+
+    yield
+  ensure
+    $stderr = original_stderr
+    $stdout = original_stdout
+  end
+
+  def capture_output
+    original_stderr = $stderr
+    original_stdout = $stdout
+
+    output = $stdout = $stderr = StringIO.new
 
     yield
 
-    # Return output
     output.string
   ensure
     $stderr = original_stderr


### PR DESCRIPTION
The issue in #866 is tricky. For some reason when using the pg adapter, active record is poisoning the transaction on unique error even though that is specifically rescued. The error does not occur with sqlite or mysql. 🤷‍♂️

I asked copilot how to let AR and company know that the transaction is not poisoned and they suggested save points. And guess what... it worked! Haha. I don't love these two extra network calls but it does fix the issue for now. 

If anyone smarter or with more time can find a more slick solution or dig into why pg handles this different than sqlite/mysql I'm all ears. 

Initially I thought the problem was because of the connection check out stuff happening before the rescue but even moving the rescue inside with_connection block didn't fix the issue for pg.

refs #867 
fixes #activerecord #866