### PR TITLE
Remove the flatten on actors to prevent delegator warning.

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -100,7 +100,7 @@ module Flipper
     #
     # Returns true if enabled, false if not.
     def enabled?(*actors)
-      actors = actors.flatten.compact.map { |actor| Types::Actor.wrap(actor) }
+      actors = actors.compact.map { |actor| Types::Actor.wrap(actor) }
       actors = nil if actors.empty?
 
       # thing is left for backwards compatibility

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -58,12 +58,12 @@ RSpec.describe Flipper::Feature do
 
       it 'returns true if feature is enabled' do
         subject.enable
-        expect(subject.enabled?(actors)).to be(true)
+        expect(subject.enabled?(*actors)).to be(true)
       end
 
       it 'returns true if feature is enabled for any actor' do
         subject.enable_actor actors.first
-        expect(subject.enabled?(actors)).to be(true)
+        expect(subject.enabled?(*actors)).to be(true)
       end
 
       it 'returns true if feature is enabled for any actor with multiple arguments' do
@@ -73,7 +73,7 @@ RSpec.describe Flipper::Feature do
 
       it 'returns false if feature is disabled for all actors' do
         subject.disable
-        expect(subject.enabled?(actors)).to be(false)
+        expect(subject.enabled?(*actors)).to be(false)
       end
     end
   end


### PR DESCRIPTION
Hi 👋 When using Flipper with actors that are `ActiveRecord` models, you get this warning whenever the application checks a feature flag:

```
...lib/flipper/feature.rb:103: warning: delegator does not forward private method #to_ary
```

There is a [thread](https://github.com/rails/rails/issues/48059) on the Rails Github issues explaining this particular  issue, although this is not a big problem per se it does mean the Flipper gem generates unnecessary noise in application logs. 

When the passing of [multiple arguments](https://github.com/flippercloud/flipper/pull/710) was built in, the intent seems to have been to allow the users to pass arguments like:

```
Flipper.enabled?(:some_feature, [user, team, org])
```

In this case, the `flatten` does seem like it is not required and could be removed which eliminates the warning?