### PR TITLE
Use reject(&:nil?) in enabled? check

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -100,6 +100,8 @@ module Flipper
     #
     # Returns true if enabled, false if not.
     def enabled?(*actors)
+      # Allows null object pattern. See PR for more.
+      # https://github.com/flippercloud/flipper/pull/887
       actors = actors.flatten.reject(&:nil?).map { |actor| Types::Actor.wrap(actor) }
       actors = nil if actors.empty?
 

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -100,7 +100,7 @@ module Flipper
     #
     # Returns true if enabled, false if not.
     def enabled?(*actors)
-      actors = actors.flatten.compact.map { |actor| Types::Actor.wrap(actor) }
+      actors = actors.flatten.reject(&:nil?).map { |actor| Types::Actor.wrap(actor) }
       actors = nil if actors.empty?
 
       # thing is left for backwards compatibility

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -76,6 +76,26 @@ RSpec.describe Flipper::Feature do
         expect(subject.enabled?(actors)).to be(false)
       end
     end
+
+    context "for an object that implements .nil? == true" do
+      let(:actor) { Flipper::Actor.new("User;1") }
+
+      before do
+        def actor.nil?
+          true
+        end
+      end
+
+      it 'returns true if feature is enabled' do
+        subject.enable
+        expect(subject.enabled?(actor)).to be(true)
+      end
+
+      it 'returns false if feature is disabled' do
+        subject.disable
+        expect(subject.enabled?(actor)).to be(false)
+      end
+    end
   end
 
   describe '#to_s' do


### PR DESCRIPTION
Rejecting nil has the advantage of allowing use of null object patterns using objects that implement nil? but are not strictly nil. This also works well with the ['actor cannot be nil' guard clause](https://github.com/flippercloud/flipper/blob/main/lib/flipper/types/actor.rb#L12) which uses `nil?` to check nilness.

Just an idea. Would love to hear if there are other ideas. Could handle it differently further down by making Types::Actor.wrap(actor) return nil instead of throw an error. Not sure if that would have unintended affects.