### PR TITLE
Avoid N+1 when loading Flipper UI Index

### DIFF
--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -17,7 +17,8 @@ module Flipper
             {}
           end
 
-          @features = flipper.features.map do |feature|
+          @features = keys.map do |feature_key|
+            feature = Flipper::Feature.new(feature_key, Flipper.adapter)
             decorated_feature = Decorators::Feature.new(feature)
 
             if Flipper::UI.configuration.show_feature_description_in_list?


### PR DESCRIPTION
Our project has many feature toggles (400+), when accessing the mounted Flipper UI app, it would take 20+ seconds for all the Feature look ups (M2 Max). On slower machines it takes minutes.

This two line change improves load speeds dramatically (22s -> 0.7s).
