### PR TITLE
Sort available groups alphabetically in UI

### DIFF
--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -125,7 +125,7 @@
                     <div class="col">
                       <select name="value" class="form-select">
                         <option value="">Select a group...</option>
-                        <% @feature.disabled_groups.each do |group| %>
+                        <% @feature.disabled_groups.sort_by(&:name).each do |group| %>
                           <option value="<%= group.name %>"><%= group.name %></option>
                         <% end %>
                       </select>


### PR DESCRIPTION
A minor nuisance when enabling a feature for a group is that once you have quite a few groups, they show up in a random* order. IMO the UI would be easier to use if they showed alphabetically. 

| Before | After |
|-------|-------|
| ![image](https://github.com/user-attachments/assets/206b8707-e480-4928-aac6-515ac23df4d5) | ![image](https://github.com/user-attachments/assets/b58020c1-7524-4aee-97b7-c1124c32c9dc) |


* technically they show in the order they are defined in your code.

I only changed this at the view layer, I wasn't sure if you want to sort groups alphabetically everywhere they're interacted with.