### PR TITLE
Add support for Rails v8.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,20 +29,34 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
-        rails: ['5.2', '6.0.0', '6.1.0', '7.0.0', '7.1.0']
+        rails: ['5.2', '6.0.0', '6.1.0', '7.0.0', '7.1.0', '7.2.0', '8.0.0']
         exclude:
           - ruby: "2.6"
             rails: "7.1.0"
           - ruby: "2.6"
             rails: "7.0.0"
+          - ruby: "2.6"
+            rails: "7.2.0"
+          - ruby: "2.6"
+            rails: "8.0.0"
           - ruby: "2.7"
             rails: "7.1.0"
+          - ruby: "2.7"
+            rails: "7.2.0"
+          - ruby: "2.7"
+            rails: "8.0.0"
           - ruby: "3.0"
             rails: "5.2"
+          - ruby: "3.0"
+            rails: "7.2.0"
+          - ruby: "3.0"
+            rails: "8.0.0"
           - ruby: "3.1"
             rails: "5.2"
           - ruby: "3.1"
             rails: "6.0.0"
+          - ruby: "3.1"
+            rails: "8.0.0"
           - ruby: "3.2"
             rails: "5.2"
           - ruby: "3.2"
@@ -56,7 +70,7 @@ jobs:
           - ruby: "3.3"
             rails: "6.1.0"
     env:
-      SQLITE3_VERSION: 1.4.1
+      SQLITE3_VERSION: ${{ matrix.rails == '8.0.0' && '2.1.0' || '1.4.1' }}
       REDIS_URL: redis://localhost:6379/0
       CI: true
       RAILS_VERSION: ${{ matrix.rails }}

--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'activerecord', '>= 4.2', '< 8'
+  gem.add_dependency 'activerecord', '>= 4.2', '< 9'
 end

--- a/flipper-active_support_cache_store.gemspec
+++ b/flipper-active_support_cache_store.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'activesupport', '>= 4.2', '< 8'
+  gem.add_dependency 'activesupport', '>= 4.2', '< 9'
 end

--- a/test_rails/system/test_help_test.rb
+++ b/test_rails/system/test_help_test.rb
@@ -6,6 +6,7 @@ return unless Rails::VERSION::MAJOR >= 7
 require "capybara/cuprite"
 require "flipper"
 require "flipper/test_help"
+require "action_controller/railtie"
 
 require 'action_dispatch/system_testing/server'
 ActionDispatch::SystemTesting::Server.silence_puma = true


### PR DESCRIPTION
This pull request relaxes the dependency requirements of flipper-active_record and flipper-active_support_cache_store to support Rails v8.x. This fixes #894.

It also adds Rails v8 and Rails v7.2 to the CI matrix.

Unfortunately, a lot of tests are currently failing, but the failures seem to be in line with the current failures on main. 