### PR TITLE
Add funding_uri to metadata.rb

### DIFF
--- a/lib/flipper/metadata.rb
+++ b/lib/flipper/metadata.rb
@@ -7,5 +7,6 @@ module Flipper
     "source_code_uri"   => "https://github.com/flippercloud/flipper",
     "bug_tracker_uri"   => "https://github.com/flippercloud/flipper/issues",
     "changelog_uri"     => "https://github.com/flippercloud/flipper/releases/tag/v#{Flipper::VERSION}",
+    "funding_uri"       => "https://github.com/sponsors/flippercloud",
   }.freeze
 end


### PR DESCRIPTION
Added your github sponsors link to `funding_uri` in metadata.rb for all the gemspecs to help increase visibility using the `bundle fund` command in Bundler.