### PR TITLE
Chill Out the Backoff Policy for Telemetry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ Dir['flipper-*.gemspec'].each do |gemspec|
   gemspec(name: "flipper-#{plugin}", development_group: plugin)
 end
 
+gem 'concurrent-ruby', '1.3.4'
 gem 'debug'
 gem 'rake'
 gem 'statsd-ruby', '~> 1.2.1'

--- a/examples/cloud/backoff_policy.rb
+++ b/examples/cloud/backoff_policy.rb
@@ -5,7 +5,7 @@ require 'flipper/cloud/telemetry/backoff_policy'
 intervals = []
 policy = Flipper::Cloud::Telemetry::BackoffPolicy.new
 
-10.times do |n|
+5.times do |n|
   intervals << policy.next_interval
 end
 

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -135,6 +135,10 @@ module Flipper
         logger.send(level, "name=flipper_cloud #{message}")
       end
 
+      def instrument(name, payload = {}, &block)
+        instrumenter.instrument(name, payload, &block)
+      end
+
       private
 
       def app_adapter

--- a/lib/flipper/cloud/telemetry.rb
+++ b/lib/flipper/cloud/telemetry.rb
@@ -76,7 +76,7 @@ module Flipper
         @metric_storage = MetricStorage.new
 
         @pool = Concurrent::FixedThreadPool.new(2, {
-          max_queue: 5,
+          max_queue: 20, # ~ 20 minutes of data at 1 minute intervals
           fallback_policy: :discard,
           name: "flipper-telemetry-post-to-cloud-pool".freeze,
         })

--- a/lib/flipper/cloud/telemetry.rb
+++ b/lib/flipper/cloud/telemetry.rb
@@ -75,7 +75,7 @@ module Flipper
 
         @metric_storage = MetricStorage.new
 
-        @pool = Concurrent::FixedThreadPool.new(2, {
+        @pool = Concurrent::FixedThreadPool.new(1, {
           max_queue: 20, # ~ 20 minutes of data at 1 minute intervals
           fallback_policy: :discard,
           name: "flipper-telemetry-post-to-cloud-pool".freeze,

--- a/lib/flipper/cloud/telemetry/backoff_policy.rb
+++ b/lib/flipper/cloud/telemetry/backoff_policy.rb
@@ -3,10 +3,10 @@ module Flipper
     class Telemetry
       class BackoffPolicy
         # Private: The default minimum timeout between intervals in milliseconds.
-        MIN_TIMEOUT_MS = 1_000
+        MIN_TIMEOUT_MS = 30_000
 
         # Private: The default maximum timeout between intervals in milliseconds.
-        MAX_TIMEOUT_MS = 30_000
+        MAX_TIMEOUT_MS = 120_000
 
         # Private: The value to multiply the current interval with for each
         # retry attempt.
@@ -67,7 +67,10 @@ module Flipper
 
           @attempts += 1
 
-          [interval, @max_timeout_ms].min
+          # cap the interval to the max timeout
+          result = [interval, @max_timeout_ms].min
+          # jitter even when maxed out
+          result == @max_timeout_ms ? add_jitter(result, 0.05) : result
         end
 
         def reset

--- a/lib/flipper/cloud/telemetry/submitter.rb
+++ b/lib/flipper/cloud/telemetry/submitter.rb
@@ -51,6 +51,7 @@ module Flipper
 
           Typecast.to_gzip(json)
         rescue => exception
+          @cloud_configuration.instrument "telemetry_error.#{Flipper::InstrumentationNamespace}", exception: exception, request_id: request_id
           @cloud_configuration.log "action=to_body request_id=#{request_id} error=#{exception.inspect}", level: :error
         end
 
@@ -63,6 +64,7 @@ module Flipper
             result, should_retry = yield
             return [result, nil] unless should_retry
           rescue => error
+            @cloud_configuration.instrument "telemetry_retry.#{Flipper::InstrumentationNamespace}", attempts_remaining: attempts_remaining, exception: error
             @cloud_configuration.log "action=post_to_cloud attempts_remaining=#{attempts_remaining} error=#{error.inspect}", level: :error
             should_retry = true
             caught_exception = error

--- a/lib/flipper/cloud/telemetry/submitter.rb
+++ b/lib/flipper/cloud/telemetry/submitter.rb
@@ -34,7 +34,7 @@ module Flipper
           return if drained.empty?
           body = to_body(drained)
           return if body.nil? || body.empty?
-          retry_with_backoff(10) { submit(body) }
+          retry_with_backoff(5) { submit(body) }
         end
 
         private

--- a/spec/flipper/cloud/telemetry/backoff_policy_spec.rb
+++ b/spec/flipper/cloud/telemetry/backoff_policy_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Flipper::Cloud::Telemetry::BackoffPolicy do
   context "#initialize" do
     it "with no options" do
       policy = described_class.new
-      expect(policy.min_timeout_ms).to eq(1_000)
-      expect(policy.max_timeout_ms).to eq(30_000)
+      expect(policy.min_timeout_ms).to eq(30_000)
+      expect(policy.max_timeout_ms).to eq(120_000)
       expect(policy.multiplier).to eq(1.5)
       expect(policy.randomization_factor).to eq(0.5)
     end
@@ -87,7 +87,7 @@ RSpec.describe Flipper::Cloud::Telemetry::BackoffPolicy do
         randomization_factor: 0.5,
       })
       10.times { policy.next_interval }
-      expect(policy.next_interval).to eq(10_000)
+      expect(policy.next_interval).to be_within(10_000*0.1).of(10_000)
     end
   end
 

--- a/spec/flipper/cloud/telemetry/submitter_spec.rb
+++ b/spec/flipper/cloud/telemetry/submitter_spec.rb
@@ -71,15 +71,15 @@ RSpec.describe Flipper::Cloud::Telemetry::Submitter do
         to_return(status: 429, body: "{}").
         to_return(status: 200, body: "{}")
       instance = described_class.new(cloud_configuration)
-      expect(instance.backoff_policy.min_timeout_ms).to eq(1_000)
-      expect(instance.backoff_policy.max_timeout_ms).to eq(30_000)
+      expect(instance.backoff_policy.min_timeout_ms).to eq(30_000)
+      expect(instance.backoff_policy.max_timeout_ms).to eq(120_000)
     end
 
     it "tries 10 times by default" do
       stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
         to_return(status: 500, body: "{}")
       subject.call(enabled_metrics)
-      expect(subject.backoff_policy.retries).to eq(9) # 9 retries + 1 initial attempt
+      expect(subject.backoff_policy.retries).to eq(4) # 4 retries + 1 initial attempt
     end
 
     [
@@ -105,7 +105,7 @@ RSpec.describe Flipper::Cloud::Telemetry::Submitter do
         stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
           to_raise(error_class)
         subject.call(enabled_metrics)
-        expect(subject.backoff_policy.retries).to eq(9)
+        expect(subject.backoff_policy.retries).to eq(4)
       end
     end
 

--- a/spec/flipper/cloud/telemetry_spec.rb
+++ b/spec/flipper/cloud/telemetry_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Flipper::Cloud::Telemetry do
     # Check the conig interval and the timer interval.
     expect(telemetry.interval).to eq(120)
     expect(telemetry.timer.execution_interval).to eq(120)
-    expect(stub).to have_been_requested.times(10)
+    expect(stub).to have_been_requested.times(5)
   end
 
   it "doesn't try to update telemetry interval from error if not response error" do
@@ -152,7 +152,7 @@ RSpec.describe Flipper::Cloud::Telemetry do
 
     expect(telemetry.interval).to eq(60)
     expect(telemetry.timer.execution_interval).to eq(60)
-    expect(stub).to have_been_requested.times(10)
+    expect(stub).to have_been_requested.times(5)
   end
 
   describe '#record' do


### PR DESCRIPTION
The old version was attacking us. 

This version is much more "hey you are doing your best and i appreciate that so i'll chill over here while you have a moment."

It'll retry for around 5 minutes and queue up to 20 minutes (assuming 1 minute interval which is default). 