### PR TITLE
docs: fix typo in Flipper initializer template

### DIFF
--- a/lib/generators/flipper/templates/initializer.rb
+++ b/lib/generators/flipper/templates/initializer.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   ## Show Flipper checks in logs
   # config.flipper.log = true
 
-  ## Reconfigure Flipper to use the Memory adaper and disable Cloud in tests
+  ## Reconfigure Flipper to use the Memory adapter and disable Cloud in tests
   # config.flipper.test_help = true
 
   ## The path that Flipper Cloud will use to sync features


### PR DESCRIPTION
Corrects a minor typo in the Flipper initializer template (`adaper` → `adapter`).