### PR TITLE
[ruby34] Fix frozen string warning

### DIFF
--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -56,15 +56,15 @@ module Flipper
         operation = event.payload[:operation]
         result = event.payload[:result]
 
-        description = 'Flipper '
-        description << "feature(#{feature_name}) " unless feature_name.nil?
-        description << "adapter(#{adapter_name}) "
-        description << "#{operation} "
+        description = ['Flipper']
+        description << "feature(#{feature_name})" unless feature_name.nil?
+        description << "adapter(#{adapter_name})"
+        description << "#{operation}"
+        description << sprintf('(%.1fms)', event.duration)
 
         details = "result=#{result.inspect}"
 
-        name = '%s (%.1fms)' % [description, event.duration]
-        debug "  #{color_name(name)}  [ #{details} ]"
+        debug "  #{color_name(description.join(' '))}  [ #{details} ]"
       end
 
       def logger


### PR DESCRIPTION
This change fixes the warning below, that appears when running Ruby 3.4.

```
.../flipper/lib/flipper/instrumentation/log_subscriber.rb:60:
warning: literal string will be frozen in the future
(run with --debug-frozen-string-literal for more information)
```