### PR TITLE
Add expression support to Flipper UI

### DIFF
--- a/examples/ui/basic.ru
+++ b/examples/ui/basic.ru
@@ -48,6 +48,8 @@ Flipper::UI.configure do |config|
   end
 
   config.application_href = "https://example.com"
+
+  config.expressions_enabled = true
 end
 
 # You can uncomment these to get some default data:

--- a/lib/flipper/expression.rb
+++ b/lib/flipper/expression.rb
@@ -45,6 +45,10 @@ module Flipper
       end
     end
 
+    def in_words
+      function.in_words(*args)
+    end
+
     def eql?(other)
       other.is_a?(self.class) && @function == other.function && @args == other.args
     end

--- a/lib/flipper/expression/constant.rb
+++ b/lib/flipper/expression/constant.rb
@@ -16,6 +16,14 @@ module Flipper
         value
       end
 
+      def in_words
+        value
+      end
+
+      def name
+        'Constant'
+      end
+
       def eql?(other)
         other.is_a?(self.class) && other.value == value
       end

--- a/lib/flipper/expressions/all.rb
+++ b/lib/flipper/expressions/all.rb
@@ -4,6 +4,13 @@ module Flipper
       def self.call(*args)
         args.all?
       end
+
+      def self.in_words(*args)
+        count = args.length
+        return args[0].in_words if count == 1
+
+        "all #{count} conditions"
+      end
     end
   end
 end

--- a/lib/flipper/expressions/any.rb
+++ b/lib/flipper/expressions/any.rb
@@ -4,6 +4,13 @@ module Flipper
       def self.call(*args)
         args.any?
       end
+
+      def self.in_words(*args)
+        count = args.length
+        return args[0].in_words if count == 1
+
+        "any #{count} conditions"
+      end
     end
   end
 end

--- a/lib/flipper/expressions/boolean.rb
+++ b/lib/flipper/expressions/boolean.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.call(value)
         Flipper::Typecast.to_boolean(value)
       end
+
+      def self.in_words(arg)
+        self.call(arg.value)
+      end
     end
   end
 end

--- a/lib/flipper/expressions/comparable.rb
+++ b/lib/flipper/expressions/comparable.rb
@@ -8,6 +8,14 @@ module Flipper
       def self.call(left, right)
         left.respond_to?(operator) && right.respond_to?(operator) && left.public_send(operator, right)
       end
+
+      def self.in_words(left, right)
+        "#{left.in_words} is #{operator_in_words} #{right.in_words}"
+      end
+
+      def self.operator_in_words
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/flipper/expressions/duration.rb
+++ b/lib/flipper/expressions/duration.rb
@@ -23,6 +23,11 @@ module Flipper
 
         scalar * SECONDS_PER[unit]
       end
+
+      def self.in_words(*args)
+        return "#{args.first.in_words} seconds" if args.size == 1
+        args.map(&:in_words).join(' ')
+      end
     end
   end
 end

--- a/lib/flipper/expressions/equal.rb
+++ b/lib/flipper/expressions/equal.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.operator
         :==
       end
+
+      def self.operator_in_words
+        'equal to'
+      end
     end
   end
 end

--- a/lib/flipper/expressions/greater_than.rb
+++ b/lib/flipper/expressions/greater_than.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.operator
         :>
       end
+
+      def self.operator_in_words
+        'greater than'
+      end
     end
   end
 end

--- a/lib/flipper/expressions/greater_than_or_equal_to.rb
+++ b/lib/flipper/expressions/greater_than_or_equal_to.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.operator
         :>=
       end
+
+      def self.operator_in_words
+        'greater than or equal to'
+      end
     end
   end
 end

--- a/lib/flipper/expressions/less_than.rb
+++ b/lib/flipper/expressions/less_than.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.operator
         :<
       end
+
+      def self.operator_in_words
+        'less than'
+      end
     end
   end
 end

--- a/lib/flipper/expressions/less_than_or_equal_to.rb
+++ b/lib/flipper/expressions/less_than_or_equal_to.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.operator
         :<=
       end
+
+      def self.operator_in_words
+        'less than or equal to'
+      end
     end
   end
 end

--- a/lib/flipper/expressions/not_equal.rb
+++ b/lib/flipper/expressions/not_equal.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.operator
         :!=
       end
+
+      def self.operator_in_words
+      'not equal to'
+      end
     end
   end
 end

--- a/lib/flipper/expressions/now.rb
+++ b/lib/flipper/expressions/now.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.call
         ::Time.now.utc
       end
+
+      def self.in_words
+        'now'
+      end
     end
   end
 end

--- a/lib/flipper/expressions/number.rb
+++ b/lib/flipper/expressions/number.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.call(value)
         Flipper::Typecast.to_number(value)
       end
+
+      def self.in_words(arg)
+        arg.in_words
+      end
     end
   end
 end

--- a/lib/flipper/expressions/percentage.rb
+++ b/lib/flipper/expressions/percentage.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.call(value)
         value.to_f.clamp(0, 100)
       end
+
+      def self.in_words(arg)
+        "#{self.call(arg.value)}%"
+      end
     end
   end
 end

--- a/lib/flipper/expressions/percentage_of_actors.rb
+++ b/lib/flipper/expressions/percentage_of_actors.rb
@@ -7,6 +7,10 @@ module Flipper
         prefix = context[:feature_name] || ""
         Zlib.crc32("#{prefix}#{text}") % (100 * SCALING_FACTOR) < percentage * SCALING_FACTOR
       end
+
+      def self.in_words(arg1, arg2)
+        "#{arg1.in_words} in #{arg2.in_words}% of actors"
+      end
     end
   end
 end

--- a/lib/flipper/expressions/property.rb
+++ b/lib/flipper/expressions/property.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.call(key, context:)
         context.dig(:properties, key.to_s)
       end
+
+      def self.in_words(arg)
+        arg.in_words
+      end
     end
   end
 end

--- a/lib/flipper/expressions/random.rb
+++ b/lib/flipper/expressions/random.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.call(max = 0)
         rand max
       end
+
+      def self.in_words(arg)
+        "random(#{arg.in_words})"
+      end
     end
   end
 end

--- a/lib/flipper/expressions/string.rb
+++ b/lib/flipper/expressions/string.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.call(value)
         value.to_s
       end
+
+      def self.in_words(arg)
+        arg.in_words
+      end
     end
   end
 end

--- a/lib/flipper/expressions/time.rb
+++ b/lib/flipper/expressions/time.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.call(value)
         ::Time.parse(value)
       end
+
+      def self.in_words(arg)
+        self.call(arg.value)
+      end
     end
   end
 end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -214,6 +214,22 @@ module Flipper
         eval(Erubi::Engine.new(path.read, escape: true).src)
       end
 
+      # Private: Renders a partial template.
+      #
+      # name - The Symbol or String name of the partial template.
+      # locals - Hash of local variables to make available in the partial.
+      #
+      # Returns the rendered partial as a string.
+      def partial(name, locals = {})
+        path = views_path.join("_#{name}.erb")
+        raise "Partial does not exist: #{path}" unless path.exist?
+
+        partial_binding = binding
+        locals.each { |key, value| partial_binding.local_variable_set(key, value) }
+
+        partial_binding.eval(Erubi::Engine.new(path.read, escape: true).src)
+      end
+
       # Internal: The path the app is mounted at.
       def script_name
         request.env['SCRIPT_NAME']

--- a/lib/flipper/ui/actions/expression_gate.rb
+++ b/lib/flipper/ui/actions/expression_gate.rb
@@ -1,0 +1,46 @@
+require 'flipper/ui/action'
+require 'flipper/ui/decorators/feature'
+require 'flipper/ui/util'
+require 'flipper/ui/expression_param_parser'
+
+module Flipper
+  module UI
+    module Actions
+      class ExpressionGate < UI::Action
+        include FeatureNameFromRoute
+
+        route %r{\A/features/(?<feature_name>.*)/expression/?\Z}
+
+        def post
+          render_read_only if read_only?
+          halt view_response(:expressions_disabled) unless Flipper::UI.configuration.expressions_enabled
+
+          feature = flipper[feature_name]
+
+          case params['operation']
+          when 'enable'
+            begin
+              parsed_expression = Flipper::UI::ExpressionParamParser.new(params["expression"]).parse
+            rescue Flipper::UI::ExpressionParamParser::InvalidJSONError
+              error = 'Expression JSON is not valid.'
+              redirect_to("/features/#{Flipper::UI::Util.escape feature.key}?error=#{Flipper::UI::Util.escape error}")
+            end
+
+            begin
+              expression = Flipper::Expression.build(parsed_expression)
+            rescue NameError, ArgumentError
+              error = 'Expression is not valid.'
+              redirect_to("/features/#{Flipper::UI::Util.escape feature.key}?error=#{Flipper::UI::Util.escape error}")
+            end
+
+            feature.enable_expression expression
+          when 'disable'
+            feature.disable_expression
+          end
+
+          redirect_to("/features/#{Flipper::UI::Util.escape feature.key}")
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -77,6 +77,9 @@ module Flipper
       # Default is false.
       attr_accessor :confirm_disable
 
+      # Public: Are expressions viewable and editable in the UI or not. Default is false.
+      attr_accessor :expressions_enabled
+
       VALID_BANNER_CLASS_VALUES = %w(
         danger
         dark
@@ -107,6 +110,7 @@ module Flipper
         @confirm_fully_enable = false
         @confirm_disable = true
         @read_only = false
+        @expressions_enabled = false
         @nav_items = [
           { title: "Features", href: "features" },
           { title: "Settings", href: "settings" },

--- a/lib/flipper/ui/decorators/feature.rb
+++ b/lib/flipper/ui/decorators/feature.rb
@@ -56,6 +56,10 @@ module Flipper
             statuses << "#{feature.percentage_of_time_value}% of time"
           end
 
+          if feature.expression && Flipper::UI.configuration.expressions_enabled
+            statuses << "actors where #{feature.expression.in_words}"
+          end
+
           Util.to_sentence(statuses)
         end
 

--- a/lib/flipper/ui/expression_param_parser.rb
+++ b/lib/flipper/ui/expression_param_parser.rb
@@ -1,0 +1,40 @@
+module Flipper
+  module UI
+    # Internal: Used to parse expressions from the UI into a format that can be
+    # used by Flipper::Expression.build
+    class ExpressionParamParser
+      class InvalidJSONError < StandardError ;end
+
+      def initialize(expression)
+        @expression = expression
+      end
+
+      def parse
+        return {} unless @expression
+
+        begin
+          return JSON.parse(@expression) if @expression.is_a?(String)
+        rescue JSON::ParserError
+          raise InvalidJSONError
+        end
+
+        convert(@expression)
+      end
+
+      private
+
+      def convert(node)
+        return node unless node.is_a?(Hash)
+        return node unless node.key?('type') && node.key?('args')
+
+        type = node['type']
+        args = node['args']
+
+        args_array = []
+        args.keys.sort.each { |k| args_array << convert(args[k]) } if args.is_a?(Hash)
+
+        { type => args_array }
+      end
+    end
+  end
+end

--- a/lib/flipper/ui/middleware.rb
+++ b/lib/flipper/ui/middleware.rb
@@ -23,6 +23,7 @@ module Flipper
         @action_collection.add UI::Actions::BooleanGate
         @action_collection.add UI::Actions::PercentageOfTimeGate
         @action_collection.add UI::Actions::PercentageOfActorsGate
+        @action_collection.add UI::Actions::ExpressionGate
         @action_collection.add UI::Actions::Feature
         @action_collection.add UI::Actions::Features
         @action_collection.add UI::Actions::Export

--- a/lib/flipper/ui/views/_all.erb
+++ b/lib/flipper/ui/views/_all.erb
@@ -1,0 +1,2 @@
+<%== partial(:group, { expression: expression, base_name: base_name }) %>
+

--- a/lib/flipper/ui/views/_any.erb
+++ b/lib/flipper/ui/views/_any.erb
@@ -1,0 +1,2 @@
+<%== partial(:group, { expression: expression, base_name: base_name }) %>
+

--- a/lib/flipper/ui/views/_boolean.erb
+++ b/lib/flipper/ui/views/_boolean.erb
@@ -1,0 +1,5 @@
+<input type="hidden" name="<%= base_name %>[type]" value="Boolean" />
+<select name="<%= base_name %>[args][0]" class="form-select">
+  <option value="true" <%= Flipper::Typecast.to_boolean(expression.args[0].value) ? 'selected' : '' %>>true</option>
+  <option value="false" <%= Flipper::Typecast.to_boolean(expression.args[0].value) ? '' : 'selected' %>>false</option>
+</select>

--- a/lib/flipper/ui/views/_comparable.erb
+++ b/lib/flipper/ui/views/_comparable.erb
@@ -1,0 +1,18 @@
+<div class="row align-items-center mb-3">
+  <div class="col">
+    <%== partial(expression.args[0].name.downcase, { expression: expression.args[0], base_name: "#{base_name}[args][0]" }) %>
+  </div>
+  <div class="col-auto">
+    <select class="form-select" name="<%= "#{base_name}[type]" %>">
+      <option value="Equal" <%= 'selected' if expression.name == 'Equal' %>>=</option>
+      <option value="NotEqual" <%= 'selected' if expression.name == 'NotEqual' %>>!=</option>
+      <option value="GreaterThan" <%= 'selected' if expression.name == 'GreaterThan' %>>></option>
+      <option value="GreaterThanOrEqualTo" <%= 'selected' if expression.name == 'GreaterThanOrEqualTo' %>>>=</option>
+      <option value="LessThan" <%= 'selected' if expression.name == 'LessThan' %>><</option>
+      <option value="LessThanOrEqualTo" <%= 'selected' if expression.name == 'LessThanOrEqualTo' %>><=</option>
+    </select>
+  </div>
+  <div class="col">
+    <%== partial(expression.args[1].name.downcase, { expression: expression.args[1], base_name: "#{base_name}[args][1]" }) %>
+  </div>
+</div>

--- a/lib/flipper/ui/views/_constant.erb
+++ b/lib/flipper/ui/views/_constant.erb
@@ -1,0 +1,1 @@
+<input type="text" name="<%= base_name %>" value="<%= expression.value %>" class="form-control" placeholder="Enter value...">

--- a/lib/flipper/ui/views/_duration.erb
+++ b/lib/flipper/ui/views/_duration.erb
@@ -1,0 +1,13 @@
+<input type="hidden" name="<%= base_name %>[type]" value="Duration" />
+<div class="row">
+  <div class="col">
+    <input type="text" name="<%= base_name %>[args][0]" value="<%= expression.args[0].value %>" class="form-control" />
+  </div>
+  <div class="col">
+    <select name="<%= base_name %>[args][1]" class="form-control">
+      <% Flipper::Expressions::Duration::SECONDS_PER.keys.each do |unit| %>
+        <option value="<%= unit %>" <%= unit == expression.args[1].value.to_s.downcase.chomp("s") ? 'selected' : '' %>><%= unit %></option>
+      <% end %>
+    </select>
+  </div>
+</div>

--- a/lib/flipper/ui/views/_equal.erb
+++ b/lib/flipper/ui/views/_equal.erb
@@ -1,0 +1,2 @@
+<%== partial(:comparable, { expression: expression, base_name: base_name }) %>
+

--- a/lib/flipper/ui/views/_greaterthan.erb
+++ b/lib/flipper/ui/views/_greaterthan.erb
@@ -1,0 +1,2 @@
+<%== partial(:comparable, { expression: expression, base_name: base_name }) %>
+

--- a/lib/flipper/ui/views/_greaterthanorequalto.erb
+++ b/lib/flipper/ui/views/_greaterthanorequalto.erb
@@ -1,0 +1,2 @@
+<%== partial(:comparable, { expression: expression, base_name: base_name }) %>
+

--- a/lib/flipper/ui/views/_group.erb
+++ b/lib/flipper/ui/views/_group.erb
@@ -1,0 +1,13 @@
+<div class="row align-items-center mb-3">
+  <div class="col-auto">
+    <select class="form-select" name="<%= base_name %>[type]">
+      <option value="Any" <%= 'selected' if expression.name == 'Any' %>>Any</option>
+      <option value="All" <%= 'selected' if expression.name == 'All' %>>All</option>
+    </select>
+  </div>
+</div>
+<div class="ms-2">
+  <% expression.args.each_with_index do |arg, index| %>
+    <%== partial(arg.name.downcase, { expression: arg, base_name: "#{base_name}[args][#{index}]" }) %>
+  <% end %>
+</div>

--- a/lib/flipper/ui/views/_lessthan.erb
+++ b/lib/flipper/ui/views/_lessthan.erb
@@ -1,0 +1,2 @@
+<%== partial(:comparable, { expression: expression, base_name: base_name }) %>
+

--- a/lib/flipper/ui/views/_lessthanorequalto.erb
+++ b/lib/flipper/ui/views/_lessthanorequalto.erb
@@ -1,0 +1,1 @@
+<%== partial(:comparable, { expression: expression, base_name: base_name }) %>

--- a/lib/flipper/ui/views/_notequal.erb
+++ b/lib/flipper/ui/views/_notequal.erb
@@ -1,0 +1,1 @@
+<%== partial(:comparable, { expression: expression, base_name: base_name }) %>

--- a/lib/flipper/ui/views/_now.erb
+++ b/lib/flipper/ui/views/_now.erb
@@ -1,0 +1,2 @@
+<input type="hidden" name="<%= base_name %>[type]" value="Now" />
+<input type="text" class="form-control" disabled value="now" />

--- a/lib/flipper/ui/views/_number.erb
+++ b/lib/flipper/ui/views/_number.erb
@@ -1,0 +1,2 @@
+<input type="hidden" name="<%= base_name %>[type]" value="Number" />
+<%== partial(:constant, { expression: expression.args[0], base_name: "#{base_name}[args][0]" }) %>

--- a/lib/flipper/ui/views/_percentage.erb
+++ b/lib/flipper/ui/views/_percentage.erb
@@ -1,0 +1,2 @@
+<input type="hidden" name="<%= base_name %>[type]" value="Percentage" />
+<%== partial(:constant, { expression: expression.args[0], base_name: "#{base_name}[args][0]" }) %>

--- a/lib/flipper/ui/views/_percentageofactors.erb
+++ b/lib/flipper/ui/views/_percentageofactors.erb
@@ -1,0 +1,9 @@
+<input type="hidden" name="<%= base_name %>[type]" value="PercentageOfActors" />
+<div class="row">
+  <div class="col">
+    <input type="text" name="<%= base_name %>[args][0]" value="<%= expression.args[0].value %>" class="form-control" />
+  </div>
+  <div class="col">
+    <input type="text" name="<%= base_name %>[args][1]" value="<%= expression.args[1].value %>" class="form-control" />
+  </div>
+</div>

--- a/lib/flipper/ui/views/_property.erb
+++ b/lib/flipper/ui/views/_property.erb
@@ -1,0 +1,2 @@
+<input type="hidden" name="<%= base_name %>[type]" value="Property" />
+<%== partial(:constant, { expression: expression.args[0], base_name: "#{base_name}[args][0]" }) %>

--- a/lib/flipper/ui/views/_random.erb
+++ b/lib/flipper/ui/views/_random.erb
@@ -1,0 +1,2 @@
+<input type="hidden" name="<%= base_name %>[type]" value="Random" />
+<%== partial(:constant, { expression: expression.args[0], base_name: "#{base_name}[args][0]" }) %>

--- a/lib/flipper/ui/views/_string.erb
+++ b/lib/flipper/ui/views/_string.erb
@@ -1,0 +1,2 @@
+<input type="hidden" name="<%= base_name %>[type]" value="String" />
+<%== partial(:constant, { expression: expression.args[0], base_name: "#{base_name}[args][0]" }) %>

--- a/lib/flipper/ui/views/_time.erb
+++ b/lib/flipper/ui/views/_time.erb
@@ -1,0 +1,2 @@
+<input type="hidden" name="<%= base_name %>[type]" value="Time" />
+<%== partial(:constant, { expression: expression.args[0], base_name: "#{base_name}[args][0]" }) %>

--- a/lib/flipper/ui/views/expressions_disabled.erb
+++ b/lib/flipper/ui/views/expressions_disabled.erb
@@ -1,0 +1,7 @@
+<div class="alert alert-info">
+  <p>Expression editing in the UI is disabled.</p>
+
+  <p>
+    To change this, you'll need to set <code>Flipper::UI.configuration.expressions_enabled = true</code> wherever flipper is running from.
+  </p>
+</div>

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -245,6 +245,79 @@
             </div>
           <% end %>
         </div>
+
+        <% if Flipper::UI.configuration.expressions_enabled %>
+          <%# Expression %>
+          <div class="js-toggle-container <%= params['expression_format'] ? 'toggle-on' : '' %>">
+            <div class="card-body border-bottom">
+              <div class="row align-items-center">
+                <div class="col col-me-auto">
+                  <h6 class="m-0">
+                    <strong class="<%= 'text-muted' unless @feature.expression %>"><% if @feature.expression %>Enabled for actors where <%= @feature.expression.in_words %><% else %>No expression enabled<% end %></strong>
+                  </h6>
+                </div>
+                <% if write_allowed? %>
+                  <div class="col col-auto toggle-block-when-off">
+                    <button class="btn btn-outline-secondary js-toggle-trigger">
+                      <%= @feature.expression ? 'Edit' : 'Add an expression' %>
+                    </button>
+                  </div>
+                  <div class="col col-auto toggle-block-when-on">
+                    <button class="btn btn-outline-secondary js-toggle-trigger">Hide</button>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+            <% if write_allowed? %>
+              <div class="card-body border-bottom toggle-block-when-on bg-lightest">
+                <form action="<%= script_name %>/features/<%= Flipper::UI::Util.escape @feature.key %>/expression" method="post" id="expression">
+                  <%== csrf_input_tag %>
+                  <input type="hidden" name="operation" value="enable">
+                  <% if @feature.expression %>
+                    <ul class="nav nav-pills mb-3">
+                      <li class="nav-item">
+                        <a class="nav-link <%= params['expression_format'] != 'json' ? 'active' : '' %>" aria-current="page" href="?expression_format=edit">Edit</a>
+                      </li>
+                      <li class="nav-item">
+                        <a class="nav-link <%= params['expression_format'] == 'json' ? 'active' : '' %>" aria-current="page" href="?expression_format=json">JSON</a>
+                      </li>
+                    </ul>
+                    <% if params['expression_format'] != 'json' %>
+                      <%== partial(@feature.expression.name.downcase, {  expression: @feature.expression,  base_name: 'expression' }) %>
+                    <% else %>
+                      <div class="mb-3">
+                        <label for="expression" class="form-label visually-hidden">Expression</label>
+                        <textarea name="expression" class="form-control" rows="10"><%= JSON.pretty_generate(@feature.expression.value) %></textarea>
+                      </div>
+                    <% end %>
+                  <% else %>
+                    <div class="mb-3">
+                      <label for="expression" class="form-label visually-hidden">Expression</label>
+                      <textarea name="expression" class="form-control" rows="3" placeholder="Enter an expression..."></textarea>
+                    </div>
+                  <% end %>
+                </form>
+                <div class="row">
+                  <div class="col-auto ms-auto">
+                    <button type="submit" form="expression" class="btn btn-primary">
+                      Save
+                    </button>
+                  </div>
+                  <% if @feature.expression %>
+                    <form action="<%= script_name %>/features/<%= Flipper::UI::Util.escape @feature.key %>/expression" method="post" class="col-auto">
+                      <%== csrf_input_tag %>
+                      <input type="hidden" name="operation" value="disable">
+                      <button type="submit" class="btn btn-outline-danger" data-bs-toggle="tooltip" title="Disable expression" data-bs-placement="left">
+                        Remove
+                      </button>
+                    </form>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
 
       <% if write_allowed? %>

--- a/spec/flipper/expressions/all_spec.rb
+++ b/spec/flipper/expressions/all_spec.rb
@@ -12,4 +12,17 @@ RSpec.describe Flipper::Expressions::All do
       expect(described_class.call).to be(true)
     end
   end
+
+  describe "#in_words" do
+    it "returns single condition for one argument" do
+      arg = double("arg", in_words: "user is admin")
+      expect(described_class.in_words(arg)).to eq("user is admin")
+    end
+
+    it "returns 'all N conditions' for multiple arguments" do
+      arg1 = double("arg1", in_words: "user is admin")
+      arg2 = double("arg2", in_words: "age > 18")
+      expect(described_class.in_words(arg1, arg2)).to eq("all 2 conditions")
+    end
+  end
 end

--- a/spec/flipper/expressions/any_spec.rb
+++ b/spec/flipper/expressions/any_spec.rb
@@ -12,4 +12,17 @@ RSpec.describe Flipper::Expressions::Any do
       expect(described_class.call).to be(false)
     end
   end
+
+  describe "#in_words" do
+    it "returns single condition for one argument" do
+      arg = double("arg", in_words: "user is admin")
+      expect(described_class.in_words(arg)).to eq("user is admin")
+    end
+
+    it "returns 'any N conditions' for multiple arguments" do
+      arg1 = double("arg1", in_words: "user is admin")
+      arg2 = double("arg2", in_words: "age > 18")
+      expect(described_class.in_words(arg1, arg2)).to eq("any 2 conditions")
+    end
+  end
 end

--- a/spec/flipper/expressions/boolean_spec.rb
+++ b/spec/flipper/expressions/boolean_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe Flipper::Expressions::Boolean do
       end
     end
   end
+
+  describe "#in_words" do
+    it "returns boolean value" do
+      arg = double("arg", value: true)
+      expect(described_class.in_words(arg)).to eq(true)
+    end
+
+    it "converts values to boolean" do
+      arg = double("arg", value: "false")
+      expect(described_class.in_words(arg)).to eq(false)
+    end
+  end
 end

--- a/spec/flipper/expressions/duration_spec.rb
+++ b/spec/flipper/expressions/duration_spec.rb
@@ -40,4 +40,17 @@ RSpec.describe Flipper::Expressions::Duration do
       expect(described_class.call(2, 'years')).to eq(63_113_904)
     end
   end
+
+  describe "#in_words" do
+    it "handles single argument" do
+      arg = double("arg", in_words: "30")
+      expect(described_class.in_words(arg)).to eq("30 seconds")
+    end
+
+    it "handles multiple arguments" do
+      arg1 = double("arg1", in_words: "1")
+      arg2 = double("arg2", in_words: "hour")
+      expect(described_class.in_words(arg1, arg2)).to eq("1 hour")
+    end
+  end
 end

--- a/spec/flipper/expressions/equal_spec.rb
+++ b/spec/flipper/expressions/equal_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe Flipper::Expressions::Equal do
       expect { described_class.call(10) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#in_words" do
+    it "formats comparison in words" do
+      left = double("left", in_words: "user_id")
+      right = double("right", in_words: "123")
+      expect(described_class.in_words(left, right)).to eq("user_id is equal to 123")
+    end
+  end
 end

--- a/spec/flipper/expressions/greater_than_or_equal_to_spec.rb
+++ b/spec/flipper/expressions/greater_than_or_equal_to_spec.rb
@@ -25,4 +25,12 @@ RSpec.describe Flipper::Expressions::GreaterThanOrEqualTo do
       expect { described_class.call(10) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#in_words" do
+    it "formats comparison in words" do
+      left = double("left", in_words: "score")
+      right = double("right", in_words: "100")
+      expect(described_class.in_words(left, right)).to eq("score is greater than or equal to 100")
+    end
+  end
 end

--- a/spec/flipper/expressions/greater_than_spec.rb
+++ b/spec/flipper/expressions/greater_than_spec.rb
@@ -25,4 +25,12 @@ RSpec.describe Flipper::Expressions::GreaterThan do
       expect { described_class.call(10) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#in_words" do
+    it "formats comparison in words" do
+      left = double("left", in_words: "age")
+      right = double("right", in_words: "18")
+      expect(described_class.in_words(left, right)).to eq("age is greater than 18")
+    end
+  end
 end

--- a/spec/flipper/expressions/less_than_or_equal_to_spec.rb
+++ b/spec/flipper/expressions/less_than_or_equal_to_spec.rb
@@ -25,4 +25,12 @@ RSpec.describe Flipper::Expressions::LessThanOrEqualTo do
       expect { described_class.call(10) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#in_words" do
+    it "formats comparison in words" do
+      left = double("left", in_words: "temperature")
+      right = double("right", in_words: "32")
+      expect(described_class.in_words(left, right)).to eq("temperature is less than or equal to 32")
+    end
+  end
 end

--- a/spec/flipper/expressions/less_than_spec.rb
+++ b/spec/flipper/expressions/less_than_spec.rb
@@ -29,4 +29,12 @@ RSpec.describe Flipper::Expressions::LessThan do
       expect { described_class.call(10) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#in_words" do
+    it "formats comparison in words" do
+      left = double("left", in_words: "age")
+      right = double("right", in_words: "65")
+      expect(described_class.in_words(left, right)).to eq("age is less than 65")
+    end
+  end
 end

--- a/spec/flipper/expressions/not_equal_spec.rb
+++ b/spec/flipper/expressions/not_equal_spec.rb
@@ -12,4 +12,12 @@ RSpec.describe Flipper::Expressions::NotEqual do
       expect { described_class.call(20, 10, 20).evaluate }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#in_words" do
+    it "formats comparison in words" do
+      left = double("left", in_words: "role")
+      right = double("right", in_words: "guest")
+      expect(described_class.in_words(left, right)).to eq("role is not equal to guest")
+    end
+  end
 end

--- a/spec/flipper/expressions/now_spec.rb
+++ b/spec/flipper/expressions/now_spec.rb
@@ -8,4 +8,10 @@ RSpec.describe Flipper::Expressions::Now do
       expect(described_class.call.zone).to eq("UTC")
     end
   end
+
+  describe "#in_words" do
+    it "returns 'now'" do
+      expect(described_class.in_words).to eq("now")
+    end
+  end
 end

--- a/spec/flipper/expressions/number_spec.rb
+++ b/spec/flipper/expressions/number_spec.rb
@@ -18,4 +18,11 @@ RSpec.describe Flipper::Expressions::Number do
       expect(described_class.call('10.1')).to be(10.1)
     end
   end
+
+  describe "#in_words" do
+    it "delegates to argument's in_words method" do
+      arg = double("arg", in_words: "42")
+      expect(described_class.in_words(arg)).to eq("42")
+    end
+  end
 end

--- a/spec/flipper/expressions/percentage_of_actors_spec.rb
+++ b/spec/flipper/expressions/percentage_of_actors_spec.rb
@@ -17,4 +17,12 @@ RSpec.describe Flipper::Expressions::PercentageOfActors do
       expect(described_class.call("User;1", 70, context: {feature_name: "b"})).to be(false)
     end
   end
+
+  describe "#in_words" do
+    it "formats as 'X in Y% of actors'" do
+      arg1 = double("arg1", in_words: "User;1")
+      arg2 = double("arg2", in_words: "25")
+      expect(described_class.in_words(arg1, arg2)).to eq("User;1 in 25% of actors")
+    end
+  end
 end

--- a/spec/flipper/expressions/percentage_spec.rb
+++ b/spec/flipper/expressions/percentage_spec.rb
@@ -12,4 +12,11 @@ RSpec.describe Flipper::Expressions::Percentage do
       expect(described_class.call(101)).to be(100)
     end
   end
+
+  describe "#in_words" do
+    it "formats as percentage" do
+      arg = double("arg", value: 75)
+      expect(described_class.in_words(arg)).to eq("75.0%")
+    end
+  end
 end

--- a/spec/flipper/expressions/property_spec.rb
+++ b/spec/flipper/expressions/property_spec.rb
@@ -10,4 +10,11 @@ RSpec.describe Flipper::Expressions::Property do
       expect(described_class.call("flipper_id", context: context)).to be(nil)
     end
   end
+
+  describe "#in_words" do
+    it "delegates to argument's in_words method" do
+      arg = double("arg", in_words: "user_id")
+      expect(described_class.in_words(arg)).to eq("user_id")
+    end
+  end
 end

--- a/spec/flipper/expressions/random_spec.rb
+++ b/spec/flipper/expressions/random_spec.rb
@@ -6,4 +6,11 @@ RSpec.describe Flipper::Expressions::Random do
       end
     end
   end
+
+  describe "#in_words" do
+    it "formats as random function" do
+      arg = double("arg", in_words: "100")
+      expect(described_class.in_words(arg)).to eq("random(100)")
+    end
+  end
 end

--- a/spec/flipper/expressions/string_spec.rb
+++ b/spec/flipper/expressions/string_spec.rb
@@ -8,4 +8,11 @@ RSpec.describe Flipper::Expressions::String do
       expect(described_class.call("test")).to eq("test")
     end
   end
+
+  describe "#in_words" do
+    it "delegates to argument's in_words method" do
+      arg = double("arg", in_words: "constant value")
+      expect(described_class.in_words(arg)).to eq("constant value")
+    end
+  end
 end

--- a/spec/flipper/expressions/time_spec.rb
+++ b/spec/flipper/expressions/time_spec.rb
@@ -10,4 +10,11 @@ RSpec.describe Flipper::Expressions::Time do
       expect(described_class.call(time.iso8601)).to eq(time)
     end
   end
+
+  describe "#in_words" do
+    it "returns parsed time" do
+      arg = double("arg", value: "2025-01-01T00:00:00Z")
+      expect(described_class.in_words(arg)).to eq("2025-01-01T00:00:00Z")
+    end
+  end
 end

--- a/spec/flipper/ui/actions/expression_gate_spec.rb
+++ b/spec/flipper/ui/actions/expression_gate_spec.rb
@@ -1,0 +1,126 @@
+RSpec.describe Flipper::UI::Actions::ExpressionGate do
+  let(:token) do
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      'a'
+    end
+  end
+  let(:session) do
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
+  end
+
+  before do
+    allow(Flipper::UI.configuration).to receive(:expressions_enabled).and_return(true)
+  end
+
+  describe 'POST /features/:feature/expression' do
+    context 'with expressions disabled' do
+      before do
+        allow(Flipper::UI.configuration).to receive(:expressions_enabled).and_return(false)
+        post 'features/search/expression',
+             { 'operation' => 'enable', 'expression' => '{"Equal": [{"Property": ["userId"]}, {"String": ["123"]}]}', 'authenticity_token' => token },
+             'rack.session' => session
+      end
+
+      it 'does not enable expression' do
+        expect(flipper[:search].expression).to be_nil
+      end
+
+      it 'renders expressions disabled view' do
+        expect(last_response.status).to be(200)
+        expect(last_response.body).to include('Expression editing in the UI is disabled')
+      end
+    end
+
+    context 'with enable operation' do
+      context 'with valid expression' do
+        before do
+          flipper.disable :search
+          post 'features/search/expression',
+               { 'operation' => 'enable', 'expression' => '{"Equal": [{"Property": ["userId"]}, {"String": ["123"]}]}', 'authenticity_token' => token },
+               'rack.session' => session
+        end
+
+        it 'enables expression on the feature' do
+          expect(flipper[:search].expression).to be_truthy
+        end
+
+        it 'redirects back to feature' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['location']).to eq('/features/search')
+        end
+      end
+
+      context 'with space in feature name' do
+        before do
+          flipper.disable "sp ace"
+          post 'features/sp%20ace/expression',
+               { 'operation' => 'enable', 'expression' => '{"Equal": [{"Property": ["userId"]}, {"String": ["123"]}]}', 'authenticity_token' => token },
+               'rack.session' => session
+        end
+
+        it 'updates feature' do
+          expect(flipper["sp ace"].expression).to be_truthy
+        end
+
+        it 'redirects back to feature' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['location']).to eq('/features/sp+ace')
+        end
+      end
+
+      context 'with invalid JSON expression' do
+        before do
+          post 'features/search/expression',
+               { 'operation' => 'enable', 'expression' => '{"invalid": json}', 'authenticity_token' => token },
+               'rack.session' => session
+        end
+
+        it 'does not enable expression' do
+          expect(flipper[:search].expression).to be_nil
+        end
+
+        it 'redirects back to feature with error' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['location']).to include('/features/search?error=Expression+JSON+is+not+valid.')
+        end
+      end
+
+      context 'with invalid expression structure' do
+        before do
+          post 'features/search/expression',
+               { 'operation' => 'enable', 'expression' => '{"invalid_expression": []}', 'authenticity_token' => token },
+               'rack.session' => session
+        end
+
+        it 'does not enable expression' do
+          expect(flipper[:search].expression).to be_nil
+        end
+
+        it 'redirects back to feature with error' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['location']).to include('/features/search?error=Expression+is+not+valid.')
+        end
+      end
+    end
+
+    context 'with disable operation' do
+      before do
+        flipper[:search].enable_expression Flipper::Expression.build({"Equal" => [{"Property" => ["userId"]}, {"String" => ["123"]}]})
+        post 'features/search/expression',
+             { 'operation' => 'disable', 'authenticity_token' => token },
+             'rack.session' => session
+      end
+
+      it 'disables expression on the feature' do
+        expect(flipper[:search].expression).to be_nil
+      end
+
+      it 'redirects back to feature' do
+        expect(last_response.status).to be(302)
+        expect(last_response.headers['location']).to eq('/features/search')
+      end
+    end
+  end
+end

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -182,4 +182,15 @@ RSpec.describe Flipper::UI::Configuration do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe "#expressions_enabled" do
+    it "has default value" do
+      expect(configuration.expressions_enabled).to eq(false)
+    end
+
+    it "can be updated" do
+      configuration.expressions_enabled = true
+      expect(configuration.expressions_enabled).to eq(true)
+    end
+  end
 end

--- a/spec/flipper/ui/expression_param_parser_spec.rb
+++ b/spec/flipper/ui/expression_param_parser_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe Flipper::UI::ExpressionParamParser do
+  describe '#parse' do
+    context 'with nil expression' do
+      it 'returns empty hash' do
+        parser = described_class.new(nil)
+        expect(parser.parse).to eq({})
+      end
+    end
+
+    context 'with empty string expression' do
+      it 'raises InvalidJSONError' do
+        parser = described_class.new('')
+        expect { parser.parse }.to raise_error(Flipper::UI::ExpressionParamParser::InvalidJSONError)
+      end
+    end
+
+    context 'with valid JSON string' do
+      it 'parses JSON string correctly' do
+        json_string = '{"Equal": [{"Property": ["userId"]}, {"String": ["123"]}]}'
+        parser = described_class.new(json_string)
+        expected = {"Equal" => [{"Property" => ["userId"]}, {"String" => ["123"]}]}
+        expect(parser.parse).to eq(expected)
+      end
+    end
+
+    context 'with invalid JSON string' do
+      it 'raises InvalidJSONError' do
+        json_string = '{"invalid": json}'
+        parser = described_class.new(json_string)
+        expect { parser.parse }.to raise_error(Flipper::UI::ExpressionParamParser::InvalidJSONError)
+      end
+    end
+
+    context 'with hash expression with type and args' do
+      it 'converts to proper format' do
+        expression = {
+          'type' => 'Equal',
+          'args' => {
+            '0' => {'type' => 'Property', 'args' => {'0' => 'userId'}},
+            '1' => {'type' => 'String', 'args' => {'0' => '123'}}
+          }
+        }
+        parser = described_class.new(expression)
+        expected = {"Equal" => [{"Property" => ["userId"]}, {"String" => ["123"]}]}
+        expect(parser.parse).to eq(expected)
+      end
+    end
+
+    context 'with nested hash expressions' do
+      it 'converts nested expressions correctly' do
+        expression = {
+          'type' => 'Any',
+          'args' => {
+            '0' => {
+              'type' => 'Equal',
+              'args' => {
+                '0' => {'type' => 'Property', 'args' => {'0' => 'userId'}},
+                '1' => {'type' => 'String', 'args' => {'0' => '123'}}
+              }
+            },
+            '1' => {
+              'type' => 'Equal',
+              'args' => {
+                '0' => {'type' => 'Property', 'args' => {'0' => 'role'}},
+                '1' => {'type' => 'String', 'args' => {'0' => 'admin'}}
+              }
+            }
+          }
+        }
+        parser = described_class.new(expression)
+        expected = {
+          "Any" => [
+            {"Equal" => [{"Property" => ["userId"]}, {"String" => ["123"]}]},
+            {"Equal" => [{"Property" => ["role"]}, {"String" => ["admin"]}]}
+          ]
+        }
+        expect(parser.parse).to eq(expected)
+      end
+    end
+
+    context 'with hash without type and args' do
+      it 'returns the hash unchanged' do
+        expression = {"some" => "data"}
+        parser = described_class.new(expression)
+        expect(parser.parse).to eq(expression)
+      end
+    end
+
+    context 'with primitive values in args' do
+      it 'preserves primitive values' do
+        expression = {
+          'type' => 'Equal',
+          'args' => {
+            '0' => 'simple_string',
+            '1' => 42
+          }
+        }
+        parser = described_class.new(expression)
+        expected = {"Equal" => ["simple_string", 42]}
+        expect(parser.parse).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey there, apologies in advance for such a large PR. At Underdog, we had a feature flag targeting request come up that was solveable with expressions, but the stakeholders were non-technical and used to interacting with Flipper via the UI.  So, I took a stab at making expressions editable in Flipper UI.

I started with an approach that used partials rendered via a similar tree traversal manner as expression evaluation. I noticed there was hardly any JS in the gem, so I tried to stick with plain Ruby and HTML.

I wanted to make expression editing as consistent as possible with the rest of the gate forms, but found that to be a lot harder than I initially thought. The permissive nature of expressions requires supporting complicated form structures. The fact that an expression can't be added to a feature without enabling the feature for all actors that match that expression means I couldn't store "incomplete" expressions on the server without making changes to features themselves or adding a new data structure. It felt like my only other option would be to add complicated JavaScript for editing expressions on the client, so I threw in the towel and added an option to edit the expression as raw JSON instead.

Everything is gated behind the configuration value `Flipper::UI.configuration.expressions_enabled`, but this still probably isn't in a shippable state. I am happy to continue working on this and get it over the line if y'all find it valuable, but it's reached the point where I felt like feedback from the maintainers was the best way to keep it moving in the right direction (if at all).

### Screenshots

The features index, with two flags enabled for expressions rendering `gates_in_words`:
<img width="602" height="287" alt="image" src="https://github.com/user-attachments/assets/14a948d8-29b1-47a0-b033-55f14e371fa0" />

A feature with a simple property-based expression:
<img width="597" height="585" alt="image" src="https://github.com/user-attachments/assets/9c16a86e-87b1-4803-875f-613ef5190942" />

Expanding the expression editing form for an `All` expression:
<img width="599" height="783" alt="image" src="https://github.com/user-attachments/assets/b31df293-a580-46a2-8491-097ca75ceb27" />

Editing the same `All` expression as JSON:

<img width="595" height="1140" alt="image" src="https://github.com/user-attachments/assets/078787f9-70d9-4838-a87b-d90bf9cd66e9" />

[An unholy expression that no one would likely ever use](https://github.com/Underdog-Inc/flipper/blob/1378c3d6a4a390e4756288e4b1af77823bd68f37/spec/flipper/ui/actions/feature_spec.rb#L179), but demonstrates the power of expressions (you can see the form styling still needs some tweaks for this type of complexity):

<img width="589" height="618" alt="image" src="https://github.com/user-attachments/assets/669642ea-0910-4f55-b0b4-eae4f836dab6" />

