### PR TITLE
Do not load ActiveRecord at require time

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -8,33 +8,35 @@ module Flipper
     class ActiveRecord
       include ::Flipper::Adapter
 
-      class Model < ::ActiveRecord::Base
-        self.abstract_class = true
-      end
+      ActiveSupport.on_load(:active_record) do
+        class Model < ::ActiveRecord::Base
+          self.abstract_class = true
+        end
 
-      # Private: Do not use outside of this adapter.
-      class Feature < Model
-        self.table_name = [
-          Model.table_name_prefix,
-          "flipper_features",
-          Model.table_name_suffix,
-        ].join
+        # Private: Do not use outside of this adapter.
+        class Feature < Model
+          self.table_name = [
+            Model.table_name_prefix,
+            "flipper_features",
+            Model.table_name_suffix,
+          ].join
 
-        has_many :gates, foreign_key: "feature_key", primary_key: "key"
+          has_many :gates, foreign_key: "feature_key", primary_key: "key"
 
-        validates :key, presence: true
-      end
+          validates :key, presence: true
+        end
 
-      # Private: Do not use outside of this adapter.
-      class Gate < Model
-        self.table_name = [
-          Model.table_name_prefix,
-          "flipper_gates",
-          Model.table_name_suffix,
-        ].join
+        # Private: Do not use outside of this adapter.
+        class Gate < Model
+          self.table_name = [
+            Model.table_name_prefix,
+            "flipper_gates",
+            Model.table_name_suffix,
+          ].join
 
-        validates :feature_key, presence: true
-        validates :key, presence: true
+          validates :feature_key, presence: true
+          validates :key, presence: true
+        end
       end
 
       VALUE_TO_TEXT_WARNING = <<-EOS


### PR DESCRIPTION
The last version removed the on_load wrapper, making flipper load ActiveRecord immediately whenever flipper is required. This causes some issues with other gems that setup their own behavior using `on_load`.

This reintroduces the on_load wrapper around the database models, which by inheriting from ActiveRecord::Base were causing ActiveRecord to be loaded at require time.

Papertrail, for example, [loads its activerecord code in an `on_load` hook](https://github.com/paper-trail-gem/paper_trail/blob/master/lib/paper_trail/frameworks/rails/railtie.rb#L25-L27). If the flipper gem is loaded first, AR will be loaded and its hooks will run before papertrail has setup its hook, meaning that papertrail's code will never run.

`on_load` was removed in #924, in a commit that reads "Now that we are lazy loading the column check we don't need this stuff I believe", so I think that the removal was not necessary for any bug fixes or features. It had previously been added in https://github.com/flippercloud/flipper/pull/832.