### PR TITLE
Add JSON Schema validation and arithmetic operators for expressions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'debug'
 gem 'rake'
 gem 'statsd-ruby', '~> 1.2.1'
 gem 'rspec', '~> 3.0'
+gem 'json_schemer' # optional; enables Flipper::Expression validation
 gem 'rack-test'
 gem 'rackup', '= 1.0.0'
 gem 'sqlite3', "~> #{ENV['SQLITE3_VERSION'] || '2.1.0'}"

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,38 @@ task release: :build do
   sh "ls pkg/*.gem | xargs -n 1 gem push --otp #{otp_code}"
 end
 
+namespace :expressions do
+  desc 'Vendor JSON Schema files from the flippercloud/expressions repo ' \
+       '(defaults to a sibling ../expressions checkout; override with SOURCE=/path/to/expressions)'
+  task :vendor do
+    require 'fileutils'
+
+    source = ENV.fetch('SOURCE') { File.expand_path('../expressions', __dir__) }
+    schemas_source = File.join(source, 'schemas')
+
+    unless File.directory?(schemas_source)
+      abort "No schemas found at #{schemas_source}. Pass SOURCE=/path/to/expressions."
+    end
+
+    dest = File.expand_path('lib/flipper/expression/schemas', __dir__)
+    FileUtils.mkdir_p(dest)
+    FileUtils.rm(Dir[File.join(dest, '*.json')])
+    FileUtils.cp(Dir[File.join(schemas_source, '*.json')], dest)
+    puts "Vendored #{Dir[File.join(dest, '*.json')].size} schema(s) into #{dest}"
+
+    # Examples are shared test cases (valid/invalid + expected results) used by
+    # spec/flipper/expression/schema_spec.rb so Ruby and JS test the same cases.
+    examples_source = File.join(source, 'examples')
+    if File.directory?(examples_source)
+      examples_dest = File.expand_path('spec/fixtures/expressions/examples', __dir__)
+      FileUtils.mkdir_p(examples_dest)
+      FileUtils.rm(Dir[File.join(examples_dest, '*.json')])
+      FileUtils.cp(Dir[File.join(examples_source, '*.json')], examples_dest)
+      puts "Vendored #{Dir[File.join(examples_dest, '*.json')].size} example(s) into #{examples_dest}"
+    end
+  end
+end
+
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = %w(--color)

--- a/flipper-api.gemspec
+++ b/flipper-api.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rack', '>= 1.4', '< 4'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
+  gem.add_dependency 'json_schemer'
 end

--- a/lib/flipper/api/v1/actions/expression_gate.rb
+++ b/lib/flipper/api/v1/actions/expression_gate.rb
@@ -15,6 +15,8 @@ module Flipper
 
             begin
               expression = Flipper::Expression.build(expression_hash)
+              raise ArgumentError unless expression.valid?
+
               feature.enable_expression expression
               decorated_feature = Decorators::Feature.new(feature)
               json_response(decorated_feature.as_json, 200)

--- a/lib/flipper/expression.rb
+++ b/lib/flipper/expression.rb
@@ -1,5 +1,6 @@
 require "flipper/expression/builder"
 require "flipper/expression/constant"
+require "flipper/expression/schema"
 
 module Flipper
   class Expression
@@ -10,14 +11,19 @@ module Flipper
 
       case object
       when Hash
-        name = object.keys.first
-        args = object.values.first
-        unless name
+        unless object.size == 1
           raise ArgumentError, "#{object.inspect} cannot be converted into an expression"
         end
 
-        new(name, Array(args).map { |o| build(o) })
-      when String, Numeric, FalseClass, TrueClass
+        name = object.keys.first
+        args = object.values.first
+
+        # Ensure args are an array, but don't use Array() because it would turn a
+        # Hash (a nested expression) into an array of key/value pairs.
+        args = args.is_a?(Hash) ? [args] : Array(args)
+
+        new(name, args.map { |o| build(o) })
+      when String, Numeric, FalseClass, TrueClass, NilClass
         Expression::Constant.new(object)
       when Symbol
         Expression::Constant.new(object.to_s)
@@ -54,6 +60,17 @@ module Flipper
       {
         name => args.map(&:value)
       }
+    end
+
+    # Public: Validate this expression against the JSON Schema. Returns an
+    # Enumerable of validation errors (empty when valid). Requires json_schemer.
+    def validate
+      Schema.instance.validate(value)
+    end
+
+    # Public: Returns true if this expression is structurally valid.
+    def valid?
+      Schema.instance.valid?(value)
     end
 
     private

--- a/lib/flipper/expression/constant.rb
+++ b/lib/flipper/expression/constant.rb
@@ -20,6 +20,17 @@ module Flipper
         other.is_a?(self.class) && other.value == value
       end
       alias_method :==, :eql?
+
+      # Public: Validate this constant against the JSON Schema. Returns an
+      # Enumerable of validation errors (empty when valid). Requires json_schemer.
+      def validate
+        Schema.instance.validate(value)
+      end
+
+      # Public: Returns true if this constant is a structurally valid expression.
+      def valid?
+        Schema.instance.valid?(value)
+      end
     end
   end
 end

--- a/lib/flipper/expression/schema.rb
+++ b/lib/flipper/expression/schema.rb
@@ -1,3 +1,5 @@
+require "flipper/typecast"
+
 module Flipper
   class Expression
     # Validates expression values against the JSON Schema vendored from

--- a/lib/flipper/expression/schema.rb
+++ b/lib/flipper/expression/schema.rb
@@ -1,0 +1,51 @@
+module Flipper
+  class Expression
+    # Validates expression values against the JSON Schema vendored from
+    # https://github.com/flippercloud/expressions (see lib/flipper/expression/schemas).
+    #
+    # Validation is optional and requires the `json_schemer` gem. Core flipper does
+    # not depend on it so that apps that only evaluate flags pay no extra weight.
+    class Schema
+      # Internal: Directory holding the vendored JSON Schema files.
+      ROOT = File.expand_path("schemas", __dir__)
+
+      # Internal: Filename => parsed schema, loaded once.
+      def self.schemas
+        @schemas ||= Dir[File.join(ROOT, "*.json")].each_with_object({}) do |path, hash|
+          hash[File.basename(path)] = Flipper::Typecast.from_json(File.read(path))
+        end
+      end
+
+      # Internal: Shared instance for the root schema. Building a JSONSchemer is
+      # relatively expensive, so reuse one across validations.
+      def self.instance
+        @instance ||= new
+      end
+
+      def initialize(schema = self.class.schemas["schema.json"])
+        require "json_schemer"
+        @schemer = JSONSchemer.schema(schema, ref_resolver: method(:resolve))
+      rescue LoadError
+        raise LoadError, "Validating Flipper expressions requires the `json_schemer` gem. " \
+                         "Add `gem \"json_schemer\"` to your Gemfile to enable it."
+      end
+
+      # Public: Returns an Enumerable of JSON Schema validation errors (empty when valid).
+      def validate(value)
+        @schemer.validate(value)
+      end
+
+      # Public: Returns true if the value is a structurally valid expression.
+      def valid?(value)
+        @schemer.valid?(value)
+      end
+
+      private
+
+      # Internal: Resolve a $ref to a sibling schema file by basename.
+      def resolve(uri)
+        self.class.schemas[File.basename(uri.path)]
+      end
+    end
+  end
+end

--- a/lib/flipper/expression/schemas/Add.schema.json
+++ b/lib/flipper/expression/schemas/Add.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Add.schema.json",
+  "title": "Add",
+  "description": "Add two values",
+  "symbol": "+",
+  "category": "Operation",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/All.schema.json
+++ b/lib/flipper/expression/schemas/All.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/All.schema.json",
+  "title": "All",
+  "description": "Returns true if all of the expressions return true.",
+  "category": "Group",
+  "symbol": "&",
+  "$ref": "schema.json#/definitions/arguments-n"
+}

--- a/lib/flipper/expression/schemas/Any.schema.json
+++ b/lib/flipper/expression/schemas/Any.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Any.schema.json",
+  "title": "Any",
+  "category": "Group",
+  "symbol": "||",
+  "description": "Returns true if any of the expressions return true.",
+  "$ref": "schema.json#/definitions/arguments-n"
+}

--- a/lib/flipper/expression/schemas/Boolean.schema.json
+++ b/lib/flipper/expression/schemas/Boolean.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Boolean.schema.json",
+  "title": "Boolean",
+  "category": "Cast",
+  "symbol": "!!",
+  "description": "Cast a value to a boolean.",
+  "$ref": "schema.json#/definitions/argument"
+}

--- a/lib/flipper/expression/schemas/Divide.schema.json
+++ b/lib/flipper/expression/schemas/Divide.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Divide.schema.json",
+  "title": "Divide",
+  "description": "Divide two values",
+  "symbol": "÷",
+  "category": "Operation",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/Duration.schema.json
+++ b/lib/flipper/expression/schemas/Duration.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Duration.schema.json",
+  "title": "Duration",
+  "description": "A period of time expressed as a number of seconds, minutes, hours, days, weeks, months, or years.",
+  "type": "array",
+  "category": "Value",
+  "items": [
+    { "$ref": "schema.json#/definitions/number" },
+    {
+      "anyOf": [
+        {
+          "title": "Unit",
+          "type": "string",
+          "enum": ["seconds", "minutes", "hours", "days", "weeks", "months", "years"]
+        },
+        { "$ref": "schema.json#/definitions/function" }
+      ]
+    }
+  ],
+  "minItems": 2,
+  "maxItems": 2
+}

--- a/lib/flipper/expression/schemas/Equal.schema.json
+++ b/lib/flipper/expression/schemas/Equal.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Equal.schema.json",
+  "title": "Equal",
+  "description": "Compare two values for equality",
+  "symbol": "=",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/FeatureEnabled.schema.json
+++ b/lib/flipper/expression/schemas/FeatureEnabled.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/FeatureEnabled.schema.json",
+  "title": "FeatureEnabled",
+  "description": "Returns true if the named feature is enabled for the current actor.",
+  "category": "Value",
+  "type": "array",
+  "items": { "$ref": "schema.json#/definitions/string" },
+  "minItems": 1,
+  "maxItems": 1
+}

--- a/lib/flipper/expression/schemas/GreaterThan.schema.json
+++ b/lib/flipper/expression/schemas/GreaterThan.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/GreaterThan.schema.json",
+  "title": "GreaterThan",
+  "description": "Compare if the first argument is > the second argument.",
+  "symbol": ">",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/GreaterThanOrEqualTo.schema.json
+++ b/lib/flipper/expression/schemas/GreaterThanOrEqualTo.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/GreaterThanOrEqualTo.schema.json",
+  "title": "GreaterThanOrEqualTo",
+  "description": "Compare if the first argument is >= the second argument.",
+  "symbol": "≥",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/LessThan.schema.json
+++ b/lib/flipper/expression/schemas/LessThan.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/LessThan.schema.json",
+  "title": "LessThan",
+  "description": "Compare if the first argument is < the second argument.",
+  "symbol": "<",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/LessThanOrEqualTo.schema.json
+++ b/lib/flipper/expression/schemas/LessThanOrEqualTo.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/LessThanOrEqualTo.schema.json",
+  "title": "LessThanOrEqualTo",
+  "description": "Compare if the first argument is < the second argument.",
+  "symbol": "≤",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/Max.schema.json
+++ b/lib/flipper/expression/schemas/Max.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Max.schema.json",
+  "title": "Max",
+  "description": "Returns the maximum value in a list.",
+  "category": "Operation",
+  "symbol": "∨",
+  "$ref": "schema.json#/definitions/arguments-n"
+}

--- a/lib/flipper/expression/schemas/Min.schema.json
+++ b/lib/flipper/expression/schemas/Min.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Min.schema.json",
+  "title": "Min",
+  "description": "Returns the minimum value in a list.",
+  "category": "Operation",
+  "symbol": "∧",
+  "$ref": "schema.json#/definitions/arguments-n"
+}

--- a/lib/flipper/expression/schemas/Multiply.schema.json
+++ b/lib/flipper/expression/schemas/Multiply.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Multiply.schema.json",
+  "title": "Multiply",
+  "description": "Multiply two values",
+  "symbol": "×",
+  "category": "Operation",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/NotEqual.schema.json
+++ b/lib/flipper/expression/schemas/NotEqual.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/NotEqual.schema.json",
+  "title": "NotEqual",
+  "description": "Compare two values for equality",
+  "symbol": "≠",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/Now.schema.json
+++ b/lib/flipper/expression/schemas/Now.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Now.schema.json",
+  "title": "Now",
+  "description": "The current time in UTC",
+  "category": "Value",
+  "type": "array",
+  "maxItems": 0
+}

--- a/lib/flipper/expression/schemas/Number.schema.json
+++ b/lib/flipper/expression/schemas/Number.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Number.schema.json",
+  "title": "Number",
+  "description": "Cast a value to a number.",
+  "category": "Cast",
+  "symbol": "#",
+  "$ref": "schema.json#/definitions/argument"
+}

--- a/lib/flipper/expression/schemas/Percentage.schema.json
+++ b/lib/flipper/expression/schemas/Percentage.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Percentage.schema.json",
+  "title": "Percentage",
+  "description": "Cast a value to a percentage between 0 and 100.",
+  "category": "Cast",
+  "symbol": "%",
+  "type": "array",
+  "items": { "$ref": "schema.json#/definitions/number" },
+  "minItems": 1,
+  "maxItems": 1
+}

--- a/lib/flipper/expression/schemas/PercentageOfActors.schema.json
+++ b/lib/flipper/expression/schemas/PercentageOfActors.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/PercentageOfActors.schema.json",
+  "title": "PercentageOfActors",
+  "description": "Returns true when the actor falls within the given percentage for the feature.",
+  "category": "Condition",
+  "type": "array",
+  "items": [
+    { "$ref": "schema.json#/definitions/string" },
+    { "$ref": "schema.json#/definitions/number" }
+  ],
+  "minItems": 2,
+  "maxItems": 2
+}

--- a/lib/flipper/expression/schemas/Property.schema.json
+++ b/lib/flipper/expression/schemas/Property.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Property.schema.json",
+  "title": "Property",
+  "description": "Extract a property from context[properties].",
+  "category": "Value",
+  "type": "array",
+  "items": { "$ref": "schema.json#/definitions/string" },
+  "minItems": 1,
+  "maxItems": 1
+}

--- a/lib/flipper/expression/schemas/Random.schema.json
+++ b/lib/flipper/expression/schemas/Random.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Random.schema.json",
+  "title": "Random",
+  "description": "Return a random number",
+  "category": "Value",
+  "type": "array",
+  "items": {
+    "title": "Maximum",
+    "description": "When max is an Integer, returns a random integer greater than or equal to zero and less than max.",
+    "anyOf": [
+      { "type": "number" },
+      { "$ref": "schema.json#/definitions/function" }
+    ]
+  },
+  "maxItems": 1
+}

--- a/lib/flipper/expression/schemas/String.schema.json
+++ b/lib/flipper/expression/schemas/String.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/String.schema.json",
+  "title": "String",
+  "description": "Cast a value to a string.",
+  "category": "Cast",
+  "symbol": "\"",
+  "$ref": "schema.json#/definitions/argument"
+}

--- a/lib/flipper/expression/schemas/Subtract.schema.json
+++ b/lib/flipper/expression/schemas/Subtract.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Subtract.schema.json",
+  "title": "Subtract",
+  "description": "Subtract two values",
+  "category": "Operation",
+  "symbol": "-",
+  "$ref": "schema.json#/definitions/operation"
+}

--- a/lib/flipper/expression/schemas/Time.schema.json
+++ b/lib/flipper/expression/schemas/Time.schema.json
@@ -9,6 +9,7 @@
     "title": "Time",
     "anyOf": [
       { "type": "string", "format": "date-time" },
+      { "type": "number" },
       { "$ref": "schema.json#/definitions/function" }
     ]
   },

--- a/lib/flipper/expression/schemas/Time.schema.json
+++ b/lib/flipper/expression/schemas/Time.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/Time.schema.json",
+  "title": "Time",
+  "description": "A time in ISO8601 format",
+  "category": "Value",
+  "type": "array",
+  "items": {
+    "title": "Time",
+    "anyOf": [
+      { "type": "string", "format": "date-time" },
+      { "$ref": "schema.json#/definitions/function" }
+    ]
+  },
+  "minItems": 1,
+  "maxItems": 1
+}

--- a/lib/flipper/expression/schemas/schema.json
+++ b/lib/flipper/expression/schemas/schema.json
@@ -65,11 +65,6 @@
       },
       "additionalProperties": false
     },
-    "property": {
-      "title": "Property Value",
-      "description": "A value stored in context[properties]: a string, number, boolean, or null.",
-      "$ref": "#/definitions/constant"
-    },
     "string": {
       "title": "String",
       "description": "A constant string value or a function that returns a string",

--- a/lib/flipper/expression/schemas/schema.json
+++ b/lib/flipper/expression/schemas/schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.flippercloud.io/expressions/schema.json",
+  "title": "Expression",
+  "description": "An expression can be a Constant or a Function",
+  "anyOf": [
+    { "$ref": "#/definitions/constant" },
+    { "$ref": "#/definitions/function" }
+  ],
+  "definitions": {
+    "constant": {
+      "title": "Constant",
+      "description": "A constant value can be a string, number or boolean",
+      "anyOf": [
+        {
+          "title": "String",
+          "type": "string"
+        },
+        {
+          "title": "Number",
+          "type": "number"
+        },
+        {
+          "title": "Boolean",
+          "type": "boolean",
+          "enum": [true, false]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "function": {
+      "title": "Function",
+      "description": "A function is an object with a single property that is the name of the function and the value is the arguments to the function",
+      "type": "object",
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "Add": { "$ref": "Add.schema.json" },
+        "All": { "$ref": "All.schema.json" },
+        "Any": { "$ref": "Any.schema.json" },
+        "Boolean": { "$ref": "Boolean.schema.json" },
+        "Divide": { "$ref": "Divide.schema.json" },
+        "Duration": { "$ref": "Duration.schema.json" },
+        "Equal": { "$ref": "Equal.schema.json" },
+        "FeatureEnabled": { "$ref": "FeatureEnabled.schema.json" },
+        "GreaterThan": { "$ref": "GreaterThan.schema.json" },
+        "GreaterThanOrEqualTo": { "$ref": "GreaterThanOrEqualTo.schema.json" },
+        "LessThan": { "$ref": "LessThan.schema.json" },
+        "LessThanOrEqualTo": { "$ref": "LessThanOrEqualTo.schema.json" },
+        "Max": { "$ref": "Max.schema.json" },
+        "Min": { "$ref": "Min.schema.json" },
+        "Multiply": { "$ref": "Multiply.schema.json" },
+        "NotEqual": { "$ref": "NotEqual.schema.json" },
+        "Now": { "$ref": "Now.schema.json" },
+        "Number": { "$ref": "Number.schema.json" },
+        "Percentage": { "$ref": "Percentage.schema.json" },
+        "PercentageOfActors": { "$ref": "PercentageOfActors.schema.json" },
+        "Property": { "$ref": "Property.schema.json" },
+        "Random": { "$ref": "Random.schema.json" },
+        "String": { "$ref": "String.schema.json" },
+        "Subtract": { "$ref": "Subtract.schema.json" },
+        "Time": { "$ref": "Time.schema.json" }
+      },
+      "additionalProperties": false
+    },
+    "property": {
+      "title": "Property Value",
+      "description": "A value stored in context[properties]: a string, number, boolean, or null.",
+      "$ref": "#/definitions/constant"
+    },
+    "string": {
+      "title": "String",
+      "description": "A constant string value or a function that returns a string",
+      "anyOf": [
+        { "type": "string" },
+        { "$ref": "#/definitions/function" }
+      ]
+    },
+    "number": {
+      "title": "Number",
+      "description": "A constant numeric value or a function that returns a number",
+      "anyOf": [
+        { "type": "number" },
+        { "$ref": "#/definitions/function" }
+      ]
+    },
+    "arguments-n": {
+      "description": "An array of expressions",
+      "type": "array",
+      "items": { "$ref": "#" },
+      "minItems": 0
+    },
+    "operation": {
+      "title": "Operation",
+      "description": "An array with exactly two expressions",
+      "category": "Condition",
+      "type": "array",
+      "items": { "$ref": "#" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "argument": {
+      "description": "An array with exactly one expression",
+      "type": "array",
+      "items": { "$ref": "#" },
+      "minItems": 1,
+      "maxItems": 1
+    }
+  }
+}

--- a/lib/flipper/expressions/add.rb
+++ b/lib/flipper/expressions/add.rb
@@ -1,0 +1,9 @@
+module Flipper
+  module Expressions
+    class Add
+      def self.call(left, right)
+        left + right
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/add.rb
+++ b/lib/flipper/expressions/add.rb
@@ -3,6 +3,8 @@ module Flipper
     class Add
       def self.call(left, right)
         left + right
+      rescue NoMethodError, TypeError
+        nil
       end
     end
   end

--- a/lib/flipper/expressions/divide.rb
+++ b/lib/flipper/expressions/divide.rb
@@ -1,0 +1,9 @@
+module Flipper
+  module Expressions
+    class Divide
+      def self.call(left, right)
+        left / right
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/divide.rb
+++ b/lib/flipper/expressions/divide.rb
@@ -2,6 +2,8 @@ module Flipper
   module Expressions
     class Divide
       def self.call(left, right)
+        return nil if right.respond_to?(:zero?) && right.zero?
+
         left.fdiv(right)
       rescue NoMethodError, TypeError, ZeroDivisionError
         nil

--- a/lib/flipper/expressions/divide.rb
+++ b/lib/flipper/expressions/divide.rb
@@ -2,7 +2,7 @@ module Flipper
   module Expressions
     class Divide
       def self.call(left, right)
-        left / right
+        left.fdiv(right)
       rescue NoMethodError, TypeError, ZeroDivisionError
         nil
       end

--- a/lib/flipper/expressions/divide.rb
+++ b/lib/flipper/expressions/divide.rb
@@ -3,6 +3,8 @@ module Flipper
     class Divide
       def self.call(left, right)
         left / right
+      rescue NoMethodError, TypeError, ZeroDivisionError
+        nil
       end
     end
   end

--- a/lib/flipper/expressions/duration.rb
+++ b/lib/flipper/expressions/duration.rb
@@ -1,0 +1,28 @@
+module Flipper
+  module Expressions
+    class Duration
+      SECONDS_PER = {
+        "second" => 1,
+        "minute" => 60,
+        "hour" => 3600,
+        "day" => 86400,
+        "week" => 604_800,
+        "month" => 2_629_746, # 1/12 of a gregorian year
+        "year" => 31_556_952, # length of a gregorian year (365.2425 days)
+      }.freeze
+
+      def self.call(scalar, unit)
+        unit = unit.to_s.downcase.chomp("s")
+
+        unless scalar.is_a?(Numeric)
+          raise ArgumentError, "Duration value must be a number but was #{scalar.inspect}"
+        end
+        unless SECONDS_PER[unit]
+          raise ArgumentError, "Duration unit #{unit.inspect} must be one of: #{SECONDS_PER.keys.join(', ')}"
+        end
+
+        scalar * SECONDS_PER[unit]
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/duration.rb
+++ b/lib/flipper/expressions/duration.rb
@@ -14,12 +14,8 @@ module Flipper
       def self.call(scalar, unit)
         unit = unit.to_s.downcase.chomp("s")
 
-        unless scalar.is_a?(Numeric)
-          raise ArgumentError, "Duration value must be a number but was #{scalar.inspect}"
-        end
-        unless SECONDS_PER[unit]
-          raise ArgumentError, "Duration unit #{unit.inspect} must be one of: #{SECONDS_PER.keys.join(', ')}"
-        end
+        return nil unless scalar.is_a?(Numeric)
+        return nil unless SECONDS_PER[unit]
 
         scalar * SECONDS_PER[unit]
       end

--- a/lib/flipper/expressions/max.rb
+++ b/lib/flipper/expressions/max.rb
@@ -3,6 +3,8 @@ module Flipper
     class Max
       def self.call(*args)
         args.max
+      rescue ArgumentError
+        nil
       end
     end
   end

--- a/lib/flipper/expressions/max.rb
+++ b/lib/flipper/expressions/max.rb
@@ -1,0 +1,9 @@
+module Flipper
+  module Expressions
+    class Max
+      def self.call(*args)
+        args.max
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/min.rb
+++ b/lib/flipper/expressions/min.rb
@@ -3,6 +3,8 @@ module Flipper
     class Min
       def self.call(*args)
         args.min
+      rescue ArgumentError
+        nil
       end
     end
   end

--- a/lib/flipper/expressions/min.rb
+++ b/lib/flipper/expressions/min.rb
@@ -1,0 +1,9 @@
+module Flipper
+  module Expressions
+    class Min
+      def self.call(*args)
+        args.min
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/multiply.rb
+++ b/lib/flipper/expressions/multiply.rb
@@ -1,0 +1,9 @@
+module Flipper
+  module Expressions
+    class Multiply
+      def self.call(left, right)
+        left * right
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/multiply.rb
+++ b/lib/flipper/expressions/multiply.rb
@@ -3,6 +3,8 @@ module Flipper
     class Multiply
       def self.call(left, right)
         left * right
+      rescue NoMethodError, TypeError
+        nil
       end
     end
   end

--- a/lib/flipper/expressions/subtract.rb
+++ b/lib/flipper/expressions/subtract.rb
@@ -1,0 +1,9 @@
+module Flipper
+  module Expressions
+    class Subtract
+      def self.call(left, right)
+        left - right
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/subtract.rb
+++ b/lib/flipper/expressions/subtract.rb
@@ -3,6 +3,8 @@ module Flipper
     class Subtract
       def self.call(left, right)
         left - right
+      rescue NoMethodError, TypeError
+        nil
       end
     end
   end

--- a/lib/flipper/gates/expression.rb
+++ b/lib/flipper/gates/expression.rb
@@ -52,8 +52,8 @@ module Flipper
       DEFAULT_PROPERTIES = {}.freeze
 
       # Internal: Property values are compared against constants in expressions,
-      # which are limited to these scalar types (see the schema's `property`
-      # definition). Values of any other type can't be meaningfully evaluated.
+      # which the schema limits to these scalar types (string, number, boolean,
+      # null). Values of any other type can't be meaningfully evaluated.
       ALLOWED_PROPERTY_TYPES = [String, Numeric, TrueClass, FalseClass, NilClass].freeze
 
       def properties(actor)

--- a/lib/flipper/gates/expression.rb
+++ b/lib/flipper/gates/expression.rb
@@ -53,8 +53,8 @@ module Flipper
 
       # Internal: Property values are compared against constants in expressions,
       # which the schema limits to these scalar types (string, number, boolean,
-      # null). Values of any other type can't be meaningfully evaluated.
-      ALLOWED_PROPERTY_TYPES = [String, Numeric, TrueClass, FalseClass, NilClass].freeze
+      # null) plus Time values returned by model datetime attributes.
+      ALLOWED_PROPERTY_TYPES = [String, Numeric, TrueClass, FalseClass, NilClass, ::Time].freeze
 
       def properties(actor)
         return DEFAULT_PROPERTIES if actor.nil?

--- a/lib/flipper/gates/expression.rb
+++ b/lib/flipper/gates/expression.rb
@@ -51,6 +51,11 @@ module Flipper
       # Internal
       DEFAULT_PROPERTIES = {}.freeze
 
+      # Internal: Property values are compared against constants in expressions,
+      # which are limited to these scalar types (see the schema's `property`
+      # definition). Values of any other type can't be meaningfully evaluated.
+      ALLOWED_PROPERTY_TYPES = [String, Numeric, TrueClass, FalseClass, NilClass].freeze
+
       def properties(actor)
         return DEFAULT_PROPERTIES if actor.nil?
 
@@ -68,7 +73,22 @@ module Flipper
           properties["flipper_id".freeze] = actor.flipper_id
         end
 
+        reject_invalid_properties(properties)
+
         properties
+      end
+
+      # Internal: Warn about and drop property values that aren't a type
+      # expressions can evaluate, rather than blowing up at evaluation time.
+      def reject_invalid_properties(properties)
+        properties.reject! do |key, value|
+          invalid = ALLOWED_PROPERTY_TYPES.none? { |type| value.is_a?(type) }
+          if invalid
+            warn "[Flipper] Ignoring property #{key.inspect} with unsupported value " \
+                 "type #{value.class} (expected String, Numeric, true, false, or nil)."
+          end
+          invalid
+        end
       end
     end
   end

--- a/spec/fixtures/expressions/examples/Add.json
+++ b/spec/fixtures/expressions/examples/Add.json
@@ -1,0 +1,24 @@
+{
+  "valid": [
+    {
+      "expression": { "Add": [2, 2] },
+      "result": { "enum": [4] }
+    },
+    {
+      "expression": { "Add": ["a", "a"] },
+      "result": { "enum": ["aa"] }
+    },
+    {
+      "expression": { "Add": [{ "Property": "age" }, 3] },
+      "context": { "properties": { "age": 18 }},
+      "result": { "enum": [21] }
+    }
+  ],
+  "invalid": [
+    { "Add": [1, 2, 3] },
+    { "Add": [1] },
+    { "Add": 1 },
+    { "Add": null },
+    { "Add": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/All.json
+++ b/spec/fixtures/expressions/examples/All.json
@@ -1,0 +1,40 @@
+{
+  "valid": [
+    {
+      "expression": { "All": [] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "All": [true] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "All": [true, false] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "All": [1, true, "string"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "All": true },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "All": false },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "All": [{ "Boolean": true }, { "Property": "admin" }] },
+      "context": { "properties": { "admin": true } },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "All": null },
+      "result": { "enum": [true] }
+    }
+  ],
+  "invalid": [
+    { "All": [], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Any.json
+++ b/spec/fixtures/expressions/examples/Any.json
@@ -1,0 +1,44 @@
+{
+  "valid": [
+    {
+      "expression": { "Any": [] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Any": [true] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Any": [true, false] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Any": [false, false] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Any": [1, true, "string"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Any": true },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Any": false },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Any": [{ "Boolean": false }, { "Property": "admin" }] },
+      "context": { "properties": { "admin": true } },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Any": null },
+      "result": { "enum": [false] }
+    }
+  ],
+  "invalid": [
+    { "Any": [], "All": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Boolean.json
+++ b/spec/fixtures/expressions/examples/Boolean.json
@@ -1,0 +1,65 @@
+{
+  "valid": [
+    {
+      "expression": { "Boolean": true },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Boolean": "true" },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Boolean": 1 },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Boolean": [true] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Boolean": ["true"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Boolean": [1] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Boolean": { "All": [] } },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Boolean": false },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Boolean": "false" },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Boolean": 0 },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Boolean": [false] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Boolean": ["false"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Boolean": [0] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Boolean": [{ "Any": [] }] },
+      "result": { "enum": [false] }
+    }
+  ],
+  "invalid": [
+    { "Boolean": null },
+    { "Boolean": [true, false] },
+    { "Boolean": true, "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Divide.json
+++ b/spec/fixtures/expressions/examples/Divide.json
@@ -1,0 +1,24 @@
+{
+  "valid": [
+    {
+      "expression": { "Divide": [6, 2] },
+      "result": { "enum": [3] }
+    },
+    {
+      "expression": { "Divide": [3, 1.5] },
+      "result": { "enum": [2.0] }
+    },
+    {
+      "expression": { "Divide": [{ "Property": "age" }, 3] },
+      "context": { "properties": { "age": 18 }},
+      "result": { "enum": [6] }
+    }
+  ],
+  "invalid": [
+    { "Divide": [1, 2, 3] },
+    { "Divide": [1] },
+    { "Divide": 1 },
+    { "Divide": null },
+    { "Divide": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Divide.json
+++ b/spec/fixtures/expressions/examples/Divide.json
@@ -13,6 +13,10 @@
       "result": { "enum": [1.5] }
     },
     {
+      "expression": { "Divide": [3, 0] },
+      "result": { "enum": [null] }
+    },
+    {
       "expression": { "Divide": [{ "Property": "age" }, 3] },
       "context": { "properties": { "age": 18 }},
       "result": { "enum": [6] }

--- a/spec/fixtures/expressions/examples/Divide.json
+++ b/spec/fixtures/expressions/examples/Divide.json
@@ -9,6 +9,10 @@
       "result": { "enum": [2.0] }
     },
     {
+      "expression": { "Divide": [3, 2] },
+      "result": { "enum": [1.5] }
+    },
+    {
       "expression": { "Divide": [{ "Property": "age" }, 3] },
       "context": { "properties": { "age": 18 }},
       "result": { "enum": [6] }

--- a/spec/fixtures/expressions/examples/Duration.json
+++ b/spec/fixtures/expressions/examples/Duration.json
@@ -1,0 +1,37 @@
+{
+  "valid": [
+    {
+      "expression": { "Duration": [2, "seconds"] },
+      "result": { "enum": [2] }
+    },
+    {
+      "expression": { "Duration": [2, "minutes"] },
+      "result": { "enum": [120] }
+    },
+    {
+      "expression": { "Duration": [2, "hours"] },
+      "result": { "enum": [7200] }
+    },
+    {
+      "expression": { "Duration": [2, "days"] },
+      "result": { "enum": [172800] }
+    },
+    {
+      "expression": { "Duration": [2, "weeks"] },
+      "result": { "enum": [1209600] }
+    },
+    {
+      "expression": { "Duration": [2, "months"] },
+      "result": { "enum": [5259492] }
+    },
+    {
+      "expression": { "Duration": [2, "years"] },
+      "result": { "enum": [63113904] }
+    }
+  ],
+  "invalid": [
+    { "Duration": [4, "score"] },
+    { "Duration": 2 },
+    { "Duration": [2] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Equal.json
+++ b/spec/fixtures/expressions/examples/Equal.json
@@ -1,0 +1,44 @@
+{
+  "valid": [
+    {
+      "expression": { "Equal": [1, 1] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Equal": ["a", "a"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Equal": [null, null] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "Equal": [null, false] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Equal": [1, 2] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Equal": ["a", "b"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Equal": [true, false] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "Equal": [{ "Property": "age" }, 21] },
+      "context": { "properties": { "age": 21 }},
+      "result": { "enum": [true] }
+    }
+  ],
+  "invalid": [
+    { "Equal": [1, 2, 3] },
+    { "Equal": [1] },
+    { "Equal": 1 },
+    { "Equal": null },
+    { "Equal": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/FeatureEnabled.json
+++ b/spec/fixtures/expressions/examples/FeatureEnabled.json
@@ -1,0 +1,15 @@
+{
+  "valid": [
+    {
+      "expression": { "FeatureEnabled": ["other_feature"] }
+    },
+    {
+      "expression": { "FeatureEnabled": [{ "Property": ["feature_name"] }] }
+    }
+  ],
+  "invalid": [
+    { "FeatureEnabled": [] },
+    { "FeatureEnabled": ["a", "b"] },
+    { "FeatureEnabled": ["a"], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/GreaterThan.json
+++ b/spec/fixtures/expressions/examples/GreaterThan.json
@@ -1,0 +1,36 @@
+{
+  "valid": [
+    {
+      "expression": { "GreaterThan": [1, 1] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "GreaterThan": ["a", "a"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "GreaterThan": [2, 1] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "GreaterThan": ["b", "a"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "GreaterThan": ["a", "b"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "GreaterThan": [{ "Property": "age" }, 18] },
+      "context": { "properties": { "age": 21 }},
+      "result": { "enum": [true] }
+    }
+  ],
+  "invalid": [
+    { "GreaterThan": [1, 2, 3] },
+    { "GreaterThan": [1] },
+    { "GreaterThan": 1 },
+    { "GreaterThan": null },
+    { "GreaterThan": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/GreaterThanOrEqualTo.json
+++ b/spec/fixtures/expressions/examples/GreaterThanOrEqualTo.json
@@ -1,0 +1,48 @@
+{
+  "valid": [
+    {
+      "expression": { "GreaterThanOrEqualTo": [1, 1] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "GreaterThanOrEqualTo": [2, 1] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "GreaterThanOrEqualTo": ["a", "b"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "GreaterThanOrEqualTo": ["b", "b"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "GreaterThanOrEqualTo": [1, 2] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "GreaterThanOrEqualTo": ["b", "a"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "GreaterThanOrEqualTo": ["a", "b"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "GreaterThanOrEqualTo": [true, false] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "GreaterThanOrEqualTo": [{ "Property": "age" }, 18] },
+      "context": { "properties": { "age": 21 }},
+      "result": { "enum": [true] }
+    }
+  ],
+  "invalid": [
+    { "GreaterThanOrEqualTo": [1, 2, 3] },
+    { "GreaterThanOrEqualTo": [1] },
+    { "GreaterThanOrEqualTo": 1 },
+    { "GreaterThanOrEqualTo": null },
+    { "GreaterThanOrEqualTo": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/LessThan.json
+++ b/spec/fixtures/expressions/examples/LessThan.json
@@ -1,0 +1,45 @@
+{
+  "valid": [
+    {
+      "expression": { "LessThan": [1, 1] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "LessThan": ["a", "a"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "LessThan": [2, 1] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "LessThan": [1, 2] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "LessThan": ["b", "a"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "LessThan": ["a", "b"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "LessThan": [{ "Property": "age" }, 18] },
+      "context": { "properties": { "age": 17 }},
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "LessThan": [{ "Property": "age" }, 18] },
+      "context": { "properties": { "age": 21 }},
+      "result": { "enum": [false] }
+    }
+  ],
+  "invalid": [
+    { "LessThan": [1, 2, 3] },
+    { "LessThan": [1] },
+    { "LessThan": 1 },
+    { "LessThan": null },
+    { "LessThan": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/LessThanOrEqualTo.json
+++ b/spec/fixtures/expressions/examples/LessThanOrEqualTo.json
@@ -1,0 +1,45 @@
+{
+  "valid": [
+    {
+      "expression": { "LessThanOrEqualTo": [1, 1] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "LessThanOrEqualTo": [2, 1] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "LessThanOrEqualTo": ["a", "b"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "LessThanOrEqualTo": ["b", "b"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "LessThanOrEqualTo": [1, 2] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "LessThanOrEqualTo": ["b", "a"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "LessThanOrEqualTo": [{ "Property": "age" }, 21] },
+      "context": { "properties": { "age": 21 }},
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "LessThanOrEqualTo": [{ "Property": "age" }, 18] },
+      "context": { "properties": { "age": 21 }},
+      "result": { "enum": [false] }
+    }
+  ],
+  "invalid": [
+    { "LessThanOrEqualTo": [1, 2, 3] },
+    { "LessThanOrEqualTo": [1] },
+    { "LessThanOrEqualTo": 1 },
+    { "LessThanOrEqualTo": null },
+    { "LessThanOrEqualTo": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Max.json
+++ b/spec/fixtures/expressions/examples/Max.json
@@ -1,0 +1,35 @@
+{
+  "valid": [
+    {
+      "expression": { "Max": [] },
+      "result": { "enum": [null] }
+    },
+    {
+      "expression": { "Max": null },
+      "result": { "enum": [null] }
+    },
+    {
+      "expression": { "Max": [3, 2, 1] },
+      "result": { "enum": [3] }
+    },
+    {
+      "expression": { "Max": [0.1, 0.2] },
+      "result": { "enum": [0.2] }
+    },
+    {
+      "expression": { "Max": ["a", "b"] },
+      "result": { "enum": ["b"] }
+    },
+    {
+      "expression": { "Max": 100 },
+      "result": { "enum": [100] }
+    },
+    {
+      "expression": { "Max": [{ "Number": "2" }, { "Number": "1" }] },
+      "result": { "enum": [2] }
+    }
+  ],
+  "invalid": [
+    { "Max": [], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Min.json
+++ b/spec/fixtures/expressions/examples/Min.json
@@ -1,0 +1,35 @@
+{
+  "valid": [
+    {
+      "expression": { "Min": [] },
+      "result": { "enum": [null] }
+    },
+    {
+      "expression": { "Min": null },
+      "result": { "enum": [null] }
+    },
+    {
+      "expression": { "Min": [3, 2, 1] },
+      "result": { "enum": [1] }
+    },
+    {
+      "expression": { "Min": [0.1, 0.2] },
+      "result": { "enum": [0.1] }
+    },
+    {
+      "expression": { "Min": ["a", "b"] },
+      "result": { "enum": ["a"] }
+    },
+    {
+      "expression": { "Min": 100 },
+      "result": { "enum": [100] }
+    },
+    {
+      "expression": { "Min": [{ "Number": "2" }, { "Number": "1" }] },
+      "result": { "enum": [1] }
+    }
+  ],
+  "invalid": [
+    { "Min": [], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Multiply.json
+++ b/spec/fixtures/expressions/examples/Multiply.json
@@ -1,0 +1,24 @@
+{
+  "valid": [
+    {
+      "expression": { "Multiply": [3, 2] },
+      "result": { "enum": [6] }
+    },
+    {
+      "expression": { "Multiply": ["foo", 2] },
+      "result": { "enum": ["foofoo"] }
+    },
+    {
+      "expression": { "Multiply": [{ "Property": "age" }, 3] },
+      "context": { "properties": { "age": 18 }},
+      "result": { "enum": [54] }
+    }
+  ],
+  "invalid": [
+    { "Multiply": [1, 2, 3] },
+    { "Multiply": [1] },
+    { "Multiply": 1 },
+    { "Multiply": null },
+    { "Multiply": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/NotEqual.json
+++ b/spec/fixtures/expressions/examples/NotEqual.json
@@ -1,0 +1,40 @@
+{
+  "valid": [
+    {
+      "expression": { "NotEqual": [1, 1] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "NotEqual": ["a", "a"] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "NotEqual": [1, 2] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "NotEqual": ["a", "b"] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "NotEqual": [true, false] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "NotEqual": [true, true] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "NotEqual": [{ "Property": "age" }, 21] },
+      "context": { "properties": { "age": 21 }},
+      "result": { "enum": [false] }
+    }
+  ],
+  "invalid": [
+    { "NotEqual": [1, 2, 3] },
+    { "NotEqual": [1] },
+    { "NotEqual": 1 },
+    { "NotEqual": null },
+    { "NotEqual": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Now.json
+++ b/spec/fixtures/expressions/examples/Now.json
@@ -1,0 +1,20 @@
+{
+  "valid": [
+    {
+      "expression": { "Now": [] },
+      "result": { "format": "date-time" }
+    },
+    {
+      "expression": { "Now": null },
+      "result": { "format": "date-time" }
+    },
+    {
+      "expression": { "String": {"Now": []} },
+      "result": { "pattern": "UTC$" }
+    }
+  ],
+  "invalid": [
+    { "Now": [1] },
+    { "Now": 1 }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Number.json
+++ b/spec/fixtures/expressions/examples/Number.json
@@ -1,0 +1,50 @@
+{
+  "valid": [
+    {
+      "expression": { "Number": 0 },
+      "result": { "enum": [0] }
+    },
+    {
+      "expression": { "Number": 1 },
+      "result": { "enum": [1] }
+    },
+    {
+      "expression": { "Number": 1.0 },
+      "result": { "enum": [1.0] }
+    },
+    {
+      "expression": { "Number": "0" },
+      "result": { "enum": [0] }
+    },
+    {
+      "expression": { "Number": "1" },
+      "result": { "enum": [1] }
+    },
+    {
+      "expression": { "Number": "1.0" },
+      "result": { "enum": [1.0] }
+    },
+    {
+      "expression": { "Number": [0] },
+      "result": { "enum": [0] }
+    },
+    {
+      "expression": { "Number": [1] },
+      "result": { "enum": [1] }
+    },
+    {
+      "expression": { "Number": [1.0] },
+      "result": { "enum": [1.0] }
+    },
+    {
+      "expression": { "Number": { "Property": "age" } },
+      "context": { "properties": { "age": 21 }},
+      "result": { "enum": [21] }
+    }
+  ],
+  "invalid": [
+    { "Number": null },
+    { "Number": [true, false] },
+    { "Number": true, "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Percentage.json
+++ b/spec/fixtures/expressions/examples/Percentage.json
@@ -1,0 +1,34 @@
+{
+  "valid": [
+    {
+      "expression": { "Percentage": [0] },
+      "result": { "enum": [0] }
+    },
+    {
+      "expression": { "Percentage": [99.999] },
+      "result": { "enum": [99.999] }
+    },
+    {
+      "expression": { "Percentage": [100] },
+      "result": { "enum": [100] }
+    },
+    {
+      "expression": { "Percentage": [{ "Property": ["nines"] }] },
+      "context": { "properties": { "nines": 99.99 } },
+      "result": { "enum": [99.99] }
+    },
+    {
+      "expression": { "Percentage": [-1] },
+      "result": { "enum": [0] }
+    },
+    {
+      "expression": { "Percentage": [101] },
+      "result": { "enum": [100] }
+    }
+  ],
+  "invalid": [
+    { "Percentage": [1, 2] },
+    { "Percentage": [null] },
+    { "Percentage": null }
+  ]
+}

--- a/spec/fixtures/expressions/examples/PercentageOfActors.json
+++ b/spec/fixtures/expressions/examples/PercentageOfActors.json
@@ -1,0 +1,48 @@
+{
+  "valid": [
+    {
+      "expression": { "PercentageOfActors": ["User;1", 42] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "PercentageOfActors": ["User;1", 0] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "PercentageOfActors": ["string", 99.99] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "PercentageOfActors": ["string", 100] },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "PercentageOfActors": [{ "Property": ["flipper_id"] }, { "Property": ["probability"] }] },
+      "context": { "properties": {"flipper_id": "User;1", "probability": 100} },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "PercentageOfActors": ["User;1", 70] },
+      "context": { "feature_name": "a" },
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": { "PercentageOfActors": ["User;1", 70] },
+      "context": { "feature_name": "b" },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "PercentageOfActors": ["string", -1] },
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": { "PercentageOfActors": ["string", 101] },
+      "result": { "enum": [true] }
+    }
+  ],
+  "invalid": [
+    { "PercentageOfActors": ["string"] },
+    { "PercentageOfActors": [100] },
+    { "PercentageOfActors": [{ "Property": ["flipper_id"] }]}
+  ]
+}

--- a/spec/fixtures/expressions/examples/Property.json
+++ b/spec/fixtures/expressions/examples/Property.json
@@ -1,0 +1,27 @@
+{
+  "valid": [
+    {
+      "expression": { "Property": "name" },
+      "context": { "properties": { "name": "value" } },
+      "result": { "enum": ["value"] }
+    },
+    {
+      "expression": { "Property": ["flipper_id"] },
+      "context": { "properties": { "flipper_id": "User;1" } },
+      "result": { "enum": ["User;1"] }
+    },
+    {
+      "expression": { "Property": ["flipper_id"] },
+      "context": { "properties": { } },
+      "result": { "enum": [null] }
+    },
+    {
+      "expression": { "Property": ["flipper_id"] },
+      "result": { "enum": [null] }
+    }
+  ],
+  "invalid": [
+    { "Property": [] },
+    { "Property": null }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Random.json
+++ b/spec/fixtures/expressions/examples/Random.json
@@ -1,0 +1,28 @@
+{
+  "valid": [
+    {
+      "expression":  { "Random": [] },
+      "result": { "type": "float", "minimum": 0, "maximum": 1 }
+    },
+    {
+      "expression":  { "Random": null },
+      "result": { "type": "float", "minimum": 0, "maximum": 1 }
+    },
+    {
+      "expression":  { "Random": 2 },
+      "result": { "type": "integer", "minimum": 0, "maximum": 1 }
+    },
+    {
+      "expression":  { "Random": [100] },
+      "result": { "type": "integer", "minimum": 0, "maximum": 99 }
+    },
+    {
+      "expression":  { "Random": [{ "Property": "max_rand" }] },
+      "context": { "properties": { "max_rand": 50 }},
+      "result": { "type": "integer", "minimum": 0, "maximum": 49 }
+    }
+  ],
+  "invalid": [
+    { "Random": [1, 2] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/String.json
+++ b/spec/fixtures/expressions/examples/String.json
@@ -1,0 +1,57 @@
+{
+  "valid": [
+    {
+      "expression": { "String": true },
+      "result": { "enum": ["true"] }
+    },
+    {
+      "expression": { "String": false },
+      "result": { "enum": ["false"] }
+    },
+    {
+      "expression": { "String": "already a string" },
+      "result": { "enum": ["already a string"] }
+    },
+    {
+      "expression": { "String": 1 },
+      "result": { "enum": ["1"] }
+    },
+    {
+      "expression": { "String": 1.1 },
+      "result": { "enum": ["1.1"] }
+    },
+  {
+      "expression": { "String": [true] },
+      "result": { "enum": ["true"] }
+    },
+    {
+      "expression": { "String": [false] },
+      "result": { "enum": ["false"] }
+    },
+    {
+      "expression": { "String": ["already a string"] },
+      "result": { "enum": ["already a string"] }
+    },
+    {
+      "expression": { "String": [1] },
+      "result": { "enum": ["1"] }
+    },
+    {
+      "expression": { "String": [1.1] },
+      "result": { "enum": ["1.1"] }
+    },
+    {
+      "expression": { "String": { "All": [] } },
+      "result": { "enum": ["true"] }
+    },
+    {
+      "expression": { "String": [{ "Any": [] }] },
+      "result": { "enum": ["false"] }
+    }
+  ],
+  "invalid": [
+    { "String": null },
+    { "String": [true, false] },
+    { "String": true, "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Subtract.json
+++ b/spec/fixtures/expressions/examples/Subtract.json
@@ -1,0 +1,20 @@
+{
+  "valid": [
+    {
+      "expression": { "Subtract": [3, 2] },
+      "result": { "enum": [1] }
+    },
+    {
+      "expression": { "Subtract": [{ "Property": "age" }, 3] },
+      "context": { "properties": { "age": 18 }},
+      "result": { "enum": [15] }
+    }
+  ],
+  "invalid": [
+    { "Subtract": [1, 2, 3] },
+    { "Subtract": [1] },
+    { "Subtract": 1 },
+    { "Subtract": null },
+    { "Subtract": [1, 2], "Any": [] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/Time.json
+++ b/spec/fixtures/expressions/examples/Time.json
@@ -1,0 +1,24 @@
+{
+  "valid": [
+    {
+      "expression": { "Number": { "Time": ["2021-01-01T00:00:00Z"] } },
+      "result": { "enum": [1609459200.0] }
+    },
+    {
+      "expression": { "Number": { "Time": "2021-01-01T00:00:00-05:00" } },
+      "result": { "enum": [1609477200.0] }
+    },
+    {
+      "expression": { "Number": { "Time": { "Property": "created_at" } } },
+      "context": { "properties": { "created_at": "2021-01-01T00:00:00Z" } },
+      "result": { "enum": [1609459200.0] }
+    }
+  ],
+  "invalid": [
+    { "Time": "2021-01-01" },
+    { "Time": "January 1, 2021 10:00" },
+    { "Time": null },
+    { "Time": false },
+    { "Time": [{ "Property": "created_at" }, { "Property": "updated_at" }] }
+  ]
+}

--- a/spec/fixtures/expressions/examples/expressions.json
+++ b/spec/fixtures/expressions/examples/expressions.json
@@ -1,0 +1,32 @@
+{
+  "valid": [
+    {
+      "expression": "string",
+      "result": { "enum": ["string"] }
+    },
+    {
+      "expression": true,
+      "result": { "enum": [true] }
+    },
+    {
+      "expression": false,
+      "result": { "enum": [false] }
+    },
+    {
+      "expression": 1,
+      "result": { "enum": [1] }
+    },
+    {
+      "expression": 1.1,
+      "result": { "enum": [1.1] }
+    },
+    {
+      "expression": null,
+      "result": { "enum": [null] }
+    }
+  ],
+  "invalid": [
+    {},
+    []
+  ]
+}

--- a/spec/flipper/api/v1/actions/expression_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/expression_gate_spec.rb
@@ -121,6 +121,23 @@ RSpec.describe Flipper::Api::V1::Actions::ExpressionGate do
     end
   end
 
+  describe 'enable with schema-invalid expression' do
+    before do
+      data = {"Add" => [1]}
+      post '/features/my_feature/expression', JSON.dump(data),
+        "CONTENT_TYPE" => "application/json"
+    end
+
+    it 'returns correct error response' do
+      expect(last_response.status).to eq(422)
+      expect(json_response).to eq(api_expression_invalid_response)
+    end
+
+    it 'does not enable the expression gate' do
+      expect(flipper[:my_feature].expression).to be(nil)
+    end
+  end
+
   describe 'enable missing feature' do
     before do
       post '/features/my_feature/expression', JSON.dump(expression.value), "CONTENT_TYPE" => "application/json"

--- a/spec/flipper/expression/schema_spec.rb
+++ b/spec/flipper/expression/schema_spec.rb
@@ -1,0 +1,54 @@
+require "flipper/expression"
+require "json_schemer"
+
+RSpec.describe Flipper::Expression::Schema do
+  schema = Flipper::Expression::Schema.instance
+  examples_glob = File.expand_path("../../fixtures/expressions/examples/*.json", __dir__)
+
+  describe ".schemas" do
+    it "loads the vendored schema files" do
+      expect(described_class.schemas).to include("schema.json", "FeatureEnabled.schema.json")
+    end
+  end
+
+  # Shared examples vendored from flippercloud/expressions so Ruby and JS test the
+  # exact same valid/invalid cases. Re-vendor with `rake expressions:vendor`.
+  Dir[examples_glob].sort.each do |path|
+    name = File.basename(path, ".json")
+    examples = Flipper::Typecast.from_json(File.read(path))
+
+    describe name do
+      Array(examples["valid"]).each do |example|
+        expression = example["expression"]
+        result = example["result"]
+        context = example["context"]&.transform_keys(&:to_sym)
+
+        describe expression.inspect do
+          it "is valid" do
+            built = Flipper::Expression.build(expression)
+            expect(built.validate.to_a).to eq([])
+            expect(built.valid?).to be(true)
+          end
+
+          if result
+            it "evaluates to a result matching #{result.inspect}" do
+              evaluated = Flipper::Expression.build(expression).evaluate(context || {})
+              # Coerce non-JSON-native values (Time) so the result schema can match.
+              value = evaluated.is_a?(::Time) ? evaluated.iso8601 : evaluated
+              expect(JSONSchemer.schema(result).valid?(value)).to be(true)
+            end
+          end
+        end
+      end
+
+      # Mirrors the JS suite in flippercloud/expressions: an invalid example is
+      # one the schema rejects. (Runtime evaluation leniency is a separate concern;
+      # validation is the enforcement point, run before an expression is saved.)
+      Array(examples["invalid"]).each do |example|
+        it "rejects #{example.inspect}" do
+          expect(schema.valid?(example)).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/flipper/expression/schema_spec.rb
+++ b/spec/flipper/expression/schema_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Flipper::Expression::Schema do
     end
   end
 
+  it "accepts numeric epoch time expressions supported by the Ruby DSL" do
+    expression = Flipper.time(123)
+
+    expect(expression.valid?).to be(true)
+  end
+
   # Shared examples vendored from flippercloud/expressions so Ruby and JS test the
   # exact same valid/invalid cases. Re-vendor with `rake expressions:vendor`.
   Dir[examples_glob].sort.each do |path|

--- a/spec/flipper/gates/expression_spec.rb
+++ b/spec/flipper/gates/expression_spec.rb
@@ -100,6 +100,23 @@ RSpec.describe Flipper::Gates::Expression do
       end
     end
 
+    context 'for properties with unsupported value types' do
+      it 'drops the value and warns instead of evaluating it' do
+        expression = Flipper.property(:tags).eq("a")
+        ctx = context(expression.value, properties: {tags: ["a", "b"]})
+        expect(subject).to receive(:warn).with(/Ignoring property "tags".*Array/)
+        expect(subject.open?(ctx)).to be(false)
+      end
+
+      it 'keeps supported scalar values alongside dropped ones' do
+        expression = Flipper.property(:plan).eq("pro")
+        ctx = context(expression.value, properties: {plan: "pro", meta: {"k" => 1}})
+        allow(subject).to receive(:warn)
+        expect(subject.open?(ctx)).to be(true)
+        expect(subject).to have_received(:warn).with(/Ignoring property "meta".*Hash/)
+      end
+    end
+
     context 'for time-based expressions' do
       it 'enables when now is past a scheduled epoch' do
         past_epoch = Time.now.to_i - 86_400

--- a/spec/flipper/gates/expression_spec.rb
+++ b/spec/flipper/gates/expression_spec.rb
@@ -192,6 +192,12 @@ RSpec.describe Flipper::Gates::Expression do
         )
         expect(subject.open?(context(expression.value))).to be(false)
       end
+
+      it 'evaluates time properties from model attributes' do
+        created_at = Time.now.utc - 86_400
+        expression = Flipper.property(:created_at).lt(Flipper.now)
+        expect(subject.open?(context(expression.value, properties: {created_at: created_at}))).to be(true)
+      end
     end
   end
 

--- a/spec/flipper/gates/expression_spec.rb
+++ b/spec/flipper/gates/expression_spec.rb
@@ -117,6 +117,25 @@ RSpec.describe Flipper::Gates::Expression do
       end
     end
 
+    context 'for arithmetic expressions with missing properties' do
+      {
+        Add: {Add: [{Property: "age"}, 3]},
+        Subtract: {Subtract: [{Property: "age"}, 3]},
+        Multiply: {Multiply: [{Property: "age"}, 3]},
+        Divide: {Divide: [{Property: "age"}, 3]},
+        Min: {Min: [{Property: "age"}, 3]},
+        Max: {Max: [{Property: "age"}, 3]},
+        Duration: {Duration: [{Property: "age"}, "seconds"]},
+      }.each do |name, operand|
+        it "returns false instead of raising for #{name}" do
+          expression = Flipper::Expression.build(GreaterThan: [operand, 20])
+          ctx = context(expression.value, properties: {plan: "pro"})
+
+          expect(subject.open?(ctx)).to be(false)
+        end
+      end
+    end
+
     context 'for time-based expressions' do
       it 'enables when now is past a scheduled epoch' do
         past_epoch = Time.now.to_i - 86_400


### PR DESCRIPTION
Adds optional JSON Schema validation for expressions using schemas vendored from [flippercloud/expressions](https://github.com/flippercloud/expressions) (no npm), exposed as `Expression#validate`/`#valid?` and backed by a lazily-required, optional `json_schemer` dependency so core stays lightweight and unburdened on the evaluate hot path. Enforces `flipper_properties` value types in `Gates::Expression` by warning about and dropping values that aren't `String`/`Numeric`/`true`/`false`/`nil`, matching the schema's scalar property definition. Brings Ruby to parity with the schema by adding the `Add`, `Subtract`, `Multiply`, `Divide`, `Min`, `Max` operators and restoring `Duration`, which together enable relative-time windows like `Now < Time(signup_at) + Duration(7, "days")`. Adds `spec/flipper/expression/schema_spec.rb`, which runs the example JSON files vendored from the expressions repo so Ruby and JS test the same cases, plus a `rake expressions:vendor` task to re-copy schemas and examples.

Note: this pairs with companion changes in flippercloud/expressions (new `FeatureEnabled` schema, scalar `property` definition); it should land after that repo is published so the vendored schemas match a release.