### PR TITLE
Initialize Flipper module state while loading

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -220,4 +220,11 @@ require 'flipper/types/percentage_of_time'
 require 'flipper/typecast'
 require 'flipper/version'
 
+# Eagerly initialize memoized module state while loading is still
+# single-threaded (require/autoload hold a per-feature lock). This avoids a
+# check-then-set race on the `||=` memoization if two threads were to first
+# touch Flipper concurrently during a parallel boot.
+Flipper.configuration
+Flipper.groups_registry
+
 require "flipper/engine" if defined?(Rails)


### PR DESCRIPTION
Flipper now initializes its memoized module state during library load, before parallel boot paths can race on first access. This covers the configuration and group registry singletons while Ruby's require/autoload lock is still serializing the feature load.

Validation: `bundle exec rspec spec/flipper_spec.rb` and `bundle exec rspec spec/flipper/engine_spec.rb` both pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex_GPT--5](https://img.shields.io/badge/Codex_GPT--5-000000)
