### PR TITLE
Require https for Flipper Cloud url

### DIFF
--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -1,5 +1,6 @@
 require "logger"
 require "socket"
+require "uri"
 require "flipper/adapters/http"
 require "flipper/adapters/poll"
 require "flipper/poller"
@@ -25,8 +26,9 @@ module Flipper
 
       # Public: The url for http adapter. Really should only be customized for
       #         development work if you are me and you are not me. Feel free to
-      #         forget you ever saw this.
-      attr_accessor :url
+      #         forget you ever saw this. Must be https so the cloud token is
+      #         never transmitted in cleartext (local development uses https too).
+      attr_reader :url
 
       # Public: net/http read timeout for all http requests (default: 5).
       attr_accessor :read_timeout
@@ -137,6 +139,16 @@ module Flipper
 
       def instrument(name, payload = {}, &block)
         instrumenter.instrument(name, payload, &block)
+      end
+
+      def url=(value)
+        unless URI(value.to_s).scheme == "https"
+          raise ArgumentError,
+            "Flipper::Cloud url must use https but was #{value.inspect}. " \
+            "https is required so your token is never sent in cleartext."
+        end
+
+        @url = value
       end
 
       private

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -1,11 +1,11 @@
 require "logger"
 require "socket"
-require "uri"
 require "flipper/adapters/http"
 require "flipper/adapters/poll"
 require "flipper/poller"
 require "flipper/adapters/dual_write"
 require "flipper/adapters/sync/synchronizer"
+require "flipper/cloud/url_validator"
 require "flipper/cloud/telemetry"
 require "flipper/cloud/telemetry/instrumenter"
 require "flipper/cloud/telemetry/submitter"
@@ -142,13 +142,7 @@ module Flipper
       end
 
       def url=(value)
-        unless URI(value.to_s).scheme == "https"
-          raise ArgumentError,
-            "Flipper::Cloud url must use https but was #{value.inspect}. " \
-            "https is required so your token is never sent in cleartext."
-        end
-
-        @url = value
+        @url = UrlValidator.validate(value)
       end
 
       private

--- a/lib/flipper/cloud/migrate.rb
+++ b/lib/flipper/cloud/migrate.rb
@@ -56,7 +56,7 @@ module Flipper
 
     # Private: Build an HTTP client for Cloud API requests.
     def self.build_client(path, headers: {})
-      base_url = https_cloud_url(ENV.fetch("FLIPPER_CLOUD_URL", DEFAULT_CLOUD_URL))
+      base_url = validate_cloud_url(ENV.fetch("FLIPPER_CLOUD_URL", DEFAULT_CLOUD_URL))
 
       Flipper::Adapters::Http::Client.new(
         url: "#{base_url}#{path}",
@@ -69,7 +69,7 @@ module Flipper
     end
     private_class_method :build_client
 
-    def self.https_cloud_url(value)
+    def self.validate_cloud_url(value)
       unless URI(value.to_s).scheme == "https"
         raise ArgumentError,
           "Flipper::Cloud url must use https but was #{value.inspect}. " \
@@ -78,6 +78,6 @@ module Flipper
 
       value
     end
-    private_class_method :https_cloud_url
+    private_class_method :validate_cloud_url
   end
 end

--- a/lib/flipper/cloud/migrate.rb
+++ b/lib/flipper/cloud/migrate.rb
@@ -1,3 +1,4 @@
+require "uri"
 require "flipper/adapters/http/client"
 require "flipper/typecast"
 
@@ -55,7 +56,7 @@ module Flipper
 
     # Private: Build an HTTP client for Cloud API requests.
     def self.build_client(path, headers: {})
-      base_url = ENV.fetch("FLIPPER_CLOUD_URL", DEFAULT_CLOUD_URL)
+      base_url = https_cloud_url(ENV.fetch("FLIPPER_CLOUD_URL", DEFAULT_CLOUD_URL))
 
       Flipper::Adapters::Http::Client.new(
         url: "#{base_url}#{path}",
@@ -67,5 +68,16 @@ module Flipper
       )
     end
     private_class_method :build_client
+
+    def self.https_cloud_url(value)
+      unless URI(value.to_s).scheme == "https"
+        raise ArgumentError,
+          "Flipper::Cloud url must use https but was #{value.inspect}. " \
+          "https is required so your token is never sent in cleartext."
+      end
+
+      value
+    end
+    private_class_method :https_cloud_url
   end
 end

--- a/lib/flipper/cloud/migrate.rb
+++ b/lib/flipper/cloud/migrate.rb
@@ -1,5 +1,5 @@
-require "uri"
 require "flipper/adapters/http/client"
+require "flipper/cloud/url_validator"
 require "flipper/typecast"
 
 module Flipper
@@ -56,7 +56,7 @@ module Flipper
 
     # Private: Build an HTTP client for Cloud API requests.
     def self.build_client(path, headers: {})
-      base_url = validate_cloud_url(ENV.fetch("FLIPPER_CLOUD_URL", DEFAULT_CLOUD_URL))
+      base_url = UrlValidator.validate(ENV.fetch("FLIPPER_CLOUD_URL", DEFAULT_CLOUD_URL))
 
       Flipper::Adapters::Http::Client.new(
         url: "#{base_url}#{path}",
@@ -69,15 +69,5 @@ module Flipper
     end
     private_class_method :build_client
 
-    def self.validate_cloud_url(value)
-      unless URI(value.to_s).scheme == "https"
-        raise ArgumentError,
-          "Flipper::Cloud url must use https but was #{value.inspect}. " \
-          "https is required so your token is never sent in cleartext."
-      end
-
-      value
-    end
-    private_class_method :validate_cloud_url
   end
 end

--- a/lib/flipper/cloud/url_validator.rb
+++ b/lib/flipper/cloud/url_validator.rb
@@ -1,0 +1,26 @@
+require "uri"
+
+module Flipper
+  module Cloud
+    module UrlValidator
+      def self.validate(value)
+        url = value.to_s.dup
+        uri = URI(url)
+
+        return url.freeze if uri.is_a?(URI::HTTPS) && !uri.host.to_s.empty?
+
+        raise_invalid_url(value)
+      rescue URI::InvalidURIError
+        raise_invalid_url(value)
+      end
+
+      def self.raise_invalid_url(value)
+        raise ArgumentError,
+          "Flipper::Cloud url must use https but was #{value.inspect}. " \
+          "https is required so your token is never sent in cleartext."
+      end
+      private_class_method :raise_invalid_url
+    end
+    private_constant :UrlValidator
+  end
+end

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -113,13 +113,21 @@ RSpec.describe Flipper::Cloud::Configuration do
   end
 
   it "can override url using options" do
-    options = required_options.merge(url: "http://localhost:5000/adapter")
+    options = required_options.merge(url: "https://localhost:5000/adapter")
     instance = described_class.new(options)
-    expect(instance.url).to eq("http://localhost:5000/adapter")
+    expect(instance.url).to eq("https://localhost:5000/adapter")
 
     instance = described_class.new(required_options)
-    instance.url = "http://localhost:5000/adapter"
-    expect(instance.url).to eq("http://localhost:5000/adapter")
+    instance.url = "https://localhost:5000/adapter"
+    expect(instance.url).to eq("https://localhost:5000/adapter")
+  end
+
+  it "requires https url" do
+    options = required_options.merge(url: "http://localhost:5000/adapter")
+    expect { described_class.new(options) }.to raise_error(ArgumentError, /must use https/)
+
+    instance = described_class.new(required_options)
+    expect { instance.url = "http://localhost:5000/adapter" }.to raise_error(ArgumentError, /must use https/)
   end
 
   it "can override URL using ENV var" do

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -123,11 +123,32 @@ RSpec.describe Flipper::Cloud::Configuration do
   end
 
   it "requires https url" do
-    options = required_options.merge(url: "http://localhost:5000/adapter")
-    expect { described_class.new(options) }.to raise_error(ArgumentError, /must use https/)
+    invalid_urls = [
+      "http://localhost:5000/adapter",
+      "https://",
+      "https:localhost:5000/adapter",
+      "https://local host:5000/adapter",
+    ]
+
+    invalid_urls.each do |url|
+      options = required_options.merge(url: url)
+      expect { described_class.new(options) }.to raise_error(ArgumentError, /must use https/)
+    end
 
     instance = described_class.new(required_options)
     expect { instance.url = "http://localhost:5000/adapter" }.to raise_error(ArgumentError, /must use https/)
+  end
+
+  it "keeps the validated url immutable" do
+    url = String.new("https://localhost:5000/adapter")
+    instance = described_class.new(required_options.merge(url: url))
+
+    url.replace("http://localhost:5000/adapter")
+
+    expect(instance.url).to eq("https://localhost:5000/adapter")
+    expect(instance.url).to be_frozen
+    expect { instance.url.replace("http://localhost:5000/adapter") }.to raise_error(FrozenError)
+    expect(instance.send(:http_adapter).client.uri.scheme).to eq("https")
   end
 
   it "can override URL using ENV var" do

--- a/spec/flipper/cloud/migrate_spec.rb
+++ b/spec/flipper/cloud/migrate_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Flipper::Cloud, ".migrate" do
 
   around do |example|
     original = ENV["FLIPPER_CLOUD_URL"]
-    ENV["FLIPPER_CLOUD_URL"] = "http://localhost:5555"
+    ENV["FLIPPER_CLOUD_URL"] = "https://localhost:5555"
     example.run
   ensure
     ENV["FLIPPER_CLOUD_URL"] = original
@@ -26,19 +26,19 @@ RSpec.describe Flipper::Cloud, ".migrate" do
 
   describe ".migrate" do
     it "returns a MigrateResult with code and url on success" do
-      stub_request(:post, "http://localhost:5555/api/migrate")
-        .to_return(status: 200, body: '{"url":"http://localhost:5555/cloud/setup/abc123"}', headers: {"Content-Type" => "application/json"})
+      stub_request(:post, "https://localhost:5555/api/migrate")
+        .to_return(status: 200, body: '{"url":"https://localhost:5555/cloud/setup/abc123"}', headers: {"Content-Type" => "application/json"})
 
       result = Flipper::Cloud.migrate(flipper)
 
       expect(result).to be_a(Flipper::Cloud::MigrateResult)
       expect(result.code).to eq(200)
-      expect(result.url).to eq("http://localhost:5555/cloud/setup/abc123")
+      expect(result.url).to eq("https://localhost:5555/cloud/setup/abc123")
     end
 
     it "sends export data and metadata in the request body" do
-      stub = stub_request(:post, "http://localhost:5555/api/migrate")
-        .to_return(status: 200, body: '{"url":"http://localhost:5555/cloud/setup/abc123"}')
+      stub = stub_request(:post, "https://localhost:5555/api/migrate")
+        .to_return(status: 200, body: '{"url":"https://localhost:5555/cloud/setup/abc123"}')
 
       Flipper::Cloud.migrate(flipper, app_name: "MyApp")
 
@@ -50,9 +50,9 @@ RSpec.describe Flipper::Cloud, ".migrate" do
     end
 
     it "sends gzip-compressed request body" do
-      stub = stub_request(:post, "http://localhost:5555/api/migrate")
+      stub = stub_request(:post, "https://localhost:5555/api/migrate")
         .with(headers: {"content-encoding" => "gzip"})
-        .to_return(status: 200, body: '{"url":"http://localhost:5555/cloud/setup/abc"}')
+        .to_return(status: 200, body: '{"url":"https://localhost:5555/cloud/setup/abc"}')
 
       Flipper::Cloud.migrate(flipper)
 
@@ -62,7 +62,7 @@ RSpec.describe Flipper::Cloud, ".migrate" do
     end
 
     it "handles error responses" do
-      stub_request(:post, "http://localhost:5555/api/migrate")
+      stub_request(:post, "https://localhost:5555/api/migrate")
         .to_return(status: 500, body: '{"error":"Internal Server Error"}')
 
       result = Flipper::Cloud.migrate(flipper)
@@ -72,7 +72,7 @@ RSpec.describe Flipper::Cloud, ".migrate" do
     end
 
     it "includes error message from response body" do
-      stub_request(:post, "http://localhost:5555/api/migrate")
+      stub_request(:post, "https://localhost:5555/api/migrate")
         .to_return(status: 422, body: '{"error":"Invalid export format"}')
 
       result = Flipper::Cloud.migrate(flipper)
@@ -82,8 +82,8 @@ RSpec.describe Flipper::Cloud, ".migrate" do
     end
 
     it "uses FLIPPER_CLOUD_URL environment variable" do
-      stub = stub_request(:post, "http://localhost:5555/api/migrate")
-        .to_return(status: 200, body: '{"url":"http://localhost:5555/cloud/setup/abc"}')
+      stub = stub_request(:post, "https://localhost:5555/api/migrate")
+        .to_return(status: 200, body: '{"url":"https://localhost:5555/cloud/setup/abc"}')
 
       Flipper::Cloud.migrate(flipper)
 
@@ -91,12 +91,12 @@ RSpec.describe Flipper::Cloud, ".migrate" do
     end
 
     it "sends content-type and accept headers" do
-      stub = stub_request(:post, "http://localhost:5555/api/migrate")
+      stub = stub_request(:post, "https://localhost:5555/api/migrate")
         .with(headers: {
           "content-type" => "application/json",
           "accept" => "application/json",
         })
-        .to_return(status: 200, body: '{"url":"http://localhost:5555/cloud/setup/abc"}')
+        .to_return(status: 200, body: '{"url":"https://localhost:5555/cloud/setup/abc"}')
 
       Flipper::Cloud.migrate(flipper)
 
@@ -106,7 +106,7 @@ RSpec.describe Flipper::Cloud, ".migrate" do
 
   describe ".push" do
     it "returns a MigrateResult with code on success" do
-      stub_request(:post, "http://localhost:5555/adapter/import")
+      stub_request(:post, "https://localhost:5555/adapter/import")
         .to_return(status: 204, body: "")
 
       result = Flipper::Cloud.push("test-token", flipper)
@@ -116,7 +116,7 @@ RSpec.describe Flipper::Cloud, ".migrate" do
     end
 
     it "sends the token as a header" do
-      stub = stub_request(:post, "http://localhost:5555/adapter/import")
+      stub = stub_request(:post, "https://localhost:5555/adapter/import")
         .with(headers: {"flipper-cloud-token" => "test-token"})
         .to_return(status: 204, body: "")
 
@@ -125,8 +125,14 @@ RSpec.describe Flipper::Cloud, ".migrate" do
       expect(stub).to have_been_requested
     end
 
+    it "requires HTTPS when sending the token" do
+      ENV["FLIPPER_CLOUD_URL"] = "http://localhost:5555"
+
+      expect { Flipper::Cloud.push("test-token", flipper) }.to raise_error(ArgumentError, /must use https/)
+    end
+
     it "sends gzip-compressed export contents as the body" do
-      stub = stub_request(:post, "http://localhost:5555/adapter/import")
+      stub = stub_request(:post, "https://localhost:5555/adapter/import")
         .with(headers: {"content-encoding" => "gzip"})
         .to_return(status: 204, body: "")
 
@@ -139,7 +145,7 @@ RSpec.describe Flipper::Cloud, ".migrate" do
     end
 
     it "handles error responses" do
-      stub_request(:post, "http://localhost:5555/adapter/import")
+      stub_request(:post, "https://localhost:5555/adapter/import")
         .to_return(status: 401, body: '{"error":"Unauthorized"}')
 
       result = Flipper::Cloud.push("bad-token", flipper)
@@ -148,7 +154,7 @@ RSpec.describe Flipper::Cloud, ".migrate" do
     end
 
     it "includes error message from response body" do
-      stub_request(:post, "http://localhost:5555/adapter/import")
+      stub_request(:post, "https://localhost:5555/adapter/import")
         .to_return(status: 401, body: '{"error":"Invalid token"}')
 
       result = Flipper::Cloud.push("bad-token", flipper)

--- a/spec/flipper/cloud/migrate_spec.rb
+++ b/spec/flipper/cloud/migrate_spec.rb
@@ -125,10 +125,18 @@ RSpec.describe Flipper::Cloud, ".migrate" do
       expect(stub).to have_been_requested
     end
 
-    it "requires HTTPS when sending the token" do
-      ENV["FLIPPER_CLOUD_URL"] = "http://localhost:5555"
+    it "requires a valid HTTPS url when sending the token" do
+      invalid_urls = [
+        "http://localhost:5555",
+        "https://",
+        "https:localhost:5555",
+        "https://local host:5555",
+      ]
 
-      expect { Flipper::Cloud.push("test-token", flipper) }.to raise_error(ArgumentError, /must use https/)
+      invalid_urls.each do |url|
+        ENV["FLIPPER_CLOUD_URL"] = url
+        expect { Flipper::Cloud.push("test-token", flipper) }.to raise_error(ArgumentError, /must use https/)
+      end
     end
 
     it "sends gzip-compressed export contents as the body" do

--- a/test_rails/system/test_help_test.rb
+++ b/test_rails/system/test_help_test.rb
@@ -36,8 +36,10 @@ class TestHelpTest < ActionDispatch::SystemTestCase
     # Reconfigure Flipper since other tests change the adapter.
     flipper_configure
 
-    # Ensure this test uses this app instance
+    # Other Rails tests mutate Rails.application. start_application rebuilds
+    # Capybara.app from the restored app, so visit("/") hits this test app.
     Rails.application = TestApp.instance
+    ActionDispatch::SystemTestCase.start_application
   end
 
   test "configures a shared adapter between tests and app" do


### PR DESCRIPTION
Flipper Cloud sends the environment token on every request via the `flipper-cloud-token` header, so a non-`https` url would transmit it in cleartext with no warning. This enforces `https` for the Cloud url in both `Cloud::Configuration#url=` (covering options, the `FLIPPER_CLOUD_URL` env var, and post-init assignment) and `Cloud::Migrate` (which also sends the token on `push`), raising `ArgumentError` otherwise. Local development now runs over `https` via Caddy, so the previous `http://localhost` allowance is out of date. Specs were updated to use `https` and to assert that plain `http` is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)