### PR TITLE
Stop poller cooperatively

### DIFF
--- a/lib/flipper/poller.rb
+++ b/lib/flipper/poller.rb
@@ -164,10 +164,17 @@ module Flipper
     def wait_for_stop(timeout)
       return true if stop_requested?
 
+      deadline = Concurrent.monotonic_time + timeout
       @stop_mutex.synchronize do
-        return true if stop_requested?
+        until stop_requested?
+          remaining = deadline - Concurrent.monotonic_time
+          break if remaining <= 0
 
-        @stop_condition.wait(@stop_mutex, timeout)
+          # ConditionVariable#wait can return early (spurious wakeups on
+          # JRuby/TruffleRuby), so keep waiting the remaining time until the
+          # deadline passes to preserve the configured poll spacing.
+          @stop_condition.wait(@stop_mutex, remaining)
+        end
         stop_requested?
       end
     end

--- a/lib/flipper/poller.rb
+++ b/lib/flipper/poller.rb
@@ -20,11 +20,11 @@ module Flipper
     def self.reset
       instances.each do |_, instance|
         instance.stop
-        instance.thread&.join(1)
       end.clear
     end
 
     MINIMUM_POLL_INTERVAL = 10
+    STOP_JOIN_TIMEOUT = 1
 
     def initialize(options = {})
       @thread = nil
@@ -35,6 +35,9 @@ module Flipper
       @last_synced_at = Concurrent::AtomicFixnum.new(0)
       @adapter = Adapters::Memory.new(nil, threadsafe: true)
       @shutdown_requested = Concurrent::AtomicBoolean.new(false)
+      @stop_requested = Concurrent::AtomicBoolean.new(false)
+      @stop_mutex = Mutex.new
+      @stop_condition = ConditionVariable.new
 
       self.interval = options.fetch(:interval, 10)
       @initial_interval = @interval
@@ -56,21 +59,44 @@ module Flipper
       @instrumenter.instrument("poller.#{InstrumentationNamespace}", {
         operation: :stop,
       })
-      @thread&.kill
+
+      @stop_mutex.synchronize do
+        @stop_requested.make_true
+        @stop_condition.broadcast
+      end
+
+      thread_to_stop = @thread
+      unless thread_to_stop
+        @stop_requested.make_false
+        return
+      end
+      return if thread_to_stop.equal?(Thread.current)
+
+      thread_to_stop.join(STOP_JOIN_TIMEOUT)
+      unless thread_to_stop.alive?
+        @thread = nil if @thread.equal?(thread_to_stop)
+        @stop_requested.make_false unless @shutdown_requested.true?
+      end
     end
 
     def run
       loop do
-        sleep jitter
+        break if stop_requested?
+
+        break if wait_for_stop(jitter)
 
         begin
           sync
         rescue
           # you can instrument these using poller.flipper
         end
+        break if stop_requested?
 
-        sleep interval
+        break if wait_for_stop(interval)
       end
+    ensure
+      @thread = nil if @thread.equal?(Thread.current)
+      @stop_requested.make_false unless @shutdown_requested.true?
     end
 
     def sync
@@ -130,9 +156,25 @@ module Flipper
       @thread && @thread.alive?
     end
 
+    def stop_requested?
+      @stop_requested.true? || @shutdown_requested.true?
+    end
+
+    def wait_for_stop(timeout)
+      return true if stop_requested?
+
+      @stop_mutex.synchronize do
+        return true if stop_requested?
+
+        @stop_condition.wait(@stop_mutex, timeout)
+        stop_requested?
+      end
+    end
+
     def reset
       @pid = Process.pid
       @shutdown_requested.make_false
+      @stop_requested.make_false
       mutex.unlock if mutex.locked?
     end
 

--- a/lib/flipper/poller.rb
+++ b/lib/flipper/poller.rb
@@ -18,9 +18,10 @@ module Flipper
     end
 
     def self.reset
-      instances.each do |_, instance|
+      instances.each do |key, instance|
         instance.stop
-      end.clear
+        instances.delete(key) unless instance.thread&.alive?
+      end
     end
 
     MINIMUM_POLL_INTERVAL = 10

--- a/lib/flipper/poller.rb
+++ b/lib/flipper/poller.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'monitor'
 require 'concurrent/utility/monotonic_time'
 require 'concurrent/map'
 require 'concurrent/atomic/atomic_fixnum'
@@ -31,6 +32,7 @@ module Flipper
       @thread = nil
       @pid = Process.pid
       @mutex = Mutex.new
+      @lifecycle_mutex = Monitor.new
       @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
       @remote_adapter = options.fetch(:remote_adapter)
       @last_synced_at = Concurrent::AtomicFixnum.new(0)
@@ -61,23 +63,24 @@ module Flipper
         operation: :stop,
       })
 
-      @stop_mutex.synchronize do
-        @stop_requested.make_true
-        @stop_condition.broadcast
+      thread_to_stop = @lifecycle_mutex.synchronize do
+        @stop_mutex.synchronize do
+          @stop_requested.make_true
+          @stop_condition.broadcast
+          if @thread
+            @thread
+          else
+            @stop_requested.make_false
+            nil
+          end
+        end
       end
 
-      thread_to_stop = @thread
-      unless thread_to_stop
-        @stop_requested.make_false
-        return
-      end
+      return unless thread_to_stop
       return if thread_to_stop.equal?(Thread.current)
 
       thread_to_stop.join(STOP_JOIN_TIMEOUT)
-      unless thread_to_stop.alive?
-        @thread = nil if @thread.equal?(thread_to_stop)
-        @stop_requested.make_false unless @shutdown_requested.true?
-      end
+      clear_thread_if_current(thread_to_stop) unless thread_to_stop.alive?
     end
 
     def run
@@ -96,8 +99,7 @@ module Flipper
         break if wait_for_stop(interval)
       end
     ensure
-      @thread = nil if @thread.equal?(Thread.current)
-      @stop_requested.make_false unless @shutdown_requested.true?
+      clear_thread_if_current(Thread.current)
     end
 
     def sync
@@ -143,8 +145,11 @@ module Flipper
 
       begin
         return if thread_alive?
-        @thread = Thread.new { run }
-        @thread&.report_on_exception = false
+        thread = @lifecycle_mutex.synchronize do
+          clear_thread_if_current(@thread) if @thread
+          @thread = Thread.new { run }
+        end
+        thread&.report_on_exception = false
         @instrumenter.instrument("poller.#{InstrumentationNamespace}", {
           operation: :thread_start,
         })
@@ -159,6 +164,17 @@ module Flipper
 
     def stop_requested?
       @stop_requested.true? || @shutdown_requested.true?
+    end
+
+    def clear_thread_if_current(thread)
+      @lifecycle_mutex.synchronize do
+        return unless @thread.equal?(thread)
+
+        @thread = nil
+        @stop_mutex.synchronize do
+          @stop_requested.make_false unless @shutdown_requested.true?
+        end
+      end
     end
 
     def wait_for_stop(timeout)

--- a/spec/flipper/poller_spec.rb
+++ b/spec/flipper/poller_spec.rb
@@ -32,6 +32,27 @@ RSpec.describe Flipper::Poller do
     end
   end
 
+  describe ".reset" do
+    it "keeps instances tracked when their worker thread is still running" do
+      poller = described_class.get("stuck", {
+        remote_adapter: remote_adapter,
+        start_automatically: false,
+        shutdown_automatically: false,
+      })
+      thread = instance_double(Thread, alive?: true)
+      poller.instance_variable_set(:@thread, thread)
+
+      expect(thread).to receive(:join).with(Flipper::Poller::STOP_JOIN_TIMEOUT)
+
+      described_class.reset
+
+      expect(described_class.get("stuck")).to be(poller)
+    ensure
+      poller&.instance_variable_set(:@thread, nil)
+      described_class.reset
+    end
+  end
+
   describe "#sync" do
     it "syncs remote adapter to local adapter" do
       stub_request(:get, "#{url}/features?exclude_gate_names=true")

--- a/spec/flipper/poller_spec.rb
+++ b/spec/flipper/poller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Flipper::Poller do
     described_class.new(
       remote_adapter: remote_adapter,
       start_automatically: false,
+      shutdown_automatically: false,
       interval: 3600 # 1 hour
     )
   end
@@ -20,6 +21,7 @@ RSpec.describe Flipper::Poller do
 
     allow(subject).to receive(:loop).and_yield # Make loop just call once
     allow(subject).to receive(:sleep)          # Disable sleep
+    allow(subject).to receive(:wait_for_stop).and_return(false) # Disable condition waits
     allow(Thread).to receive(:new).and_yield   # Disable separate thread
   end
 
@@ -345,6 +347,77 @@ RSpec.describe Flipper::Poller do
         subject.sync
         expect(subject.interval).to eq(original_interval)
       end
+    end
+  end
+
+  describe "#stop" do
+    it "requests stop, joins the worker thread, and clears the thread reference" do
+      thread = instance_double(Thread)
+      subject.instance_variable_set(:@thread, thread)
+
+      expect(thread).not_to receive(:kill)
+      expect(thread).to receive(:alive?).and_return(false)
+      expect(thread).to receive(:join).with(Flipper::Poller::STOP_JOIN_TIMEOUT)
+
+      subject.stop
+
+      expect(subject.thread).to be(nil)
+      expect(subject.instance_variable_get(:@shutdown_requested)).to be_false
+      expect(subject.instance_variable_get(:@stop_requested)).to be_false
+    end
+
+    it "allows the poller to start again after a normal stop" do
+      thread = instance_double(Thread)
+      subject.instance_variable_set(:@thread, thread)
+
+      allow(thread).to receive(:alive?).and_return(false)
+      allow(thread).to receive(:join).with(Flipper::Poller::STOP_JOIN_TIMEOUT)
+
+      subject.stop
+
+      expect(Thread).to receive(:new).and_yield
+      expect(subject).to receive(:loop).and_yield
+      expect(subject).to receive(:sync)
+      subject.start
+    end
+
+    it "does not wait indefinitely for a worker that has not stopped yet" do
+      thread = instance_double(Thread, alive?: true)
+      subject.instance_variable_set(:@thread, thread)
+
+      expect(thread).to receive(:join).with(Flipper::Poller::STOP_JOIN_TIMEOUT)
+
+      subject.stop
+
+      expect(subject.thread).to be(thread)
+      expect(subject.instance_variable_get(:@stop_requested)).to be_true
+    end
+
+    it "does not kill itself when shutdown is requested from the poller thread" do
+      stub_request(:get, "#{url}/features?exclude_gate_names=true")
+        .to_return(
+          status: 200,
+          body: JSON.generate(features: []),
+          headers: { "poll-shutdown" => "true" }
+        )
+
+      subject.instance_variable_set(:@thread, Thread.current)
+
+      expect(Thread.current).not_to receive(:kill)
+
+      subject.run
+
+      expect(subject.thread).to be(nil)
+    end
+
+    it "does not wait for the interval if stop was requested before the wait begins" do
+      allow(subject).to receive(:wait_for_stop).and_call_original
+      subject.instance_variable_get(:@stop_requested).make_true
+
+      started_at = Concurrent.monotonic_time
+      expect(subject.send(:wait_for_stop, 3600)).to be(true)
+
+      expect(Concurrent.monotonic_time - started_at).to be < 0.1
     end
   end
 

--- a/spec/flipper/poller_spec.rb
+++ b/spec/flipper/poller_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Flipper::Poller do
       .to_return(status: 200, body: JSON.generate(features: []))
 
     allow(subject).to receive(:loop).and_yield # Make loop just call once
-    allow(subject).to receive(:sleep)          # Disable sleep
     allow(subject).to receive(:wait_for_stop).and_return(false) # Disable condition waits
     allow(Thread).to receive(:new).and_yield   # Disable separate thread
   end
@@ -412,6 +411,42 @@ RSpec.describe Flipper::Poller do
 
       expect(subject.thread).to be(thread)
       expect(subject.instance_variable_get(:@stop_requested)).to be_true
+    end
+
+    it "does not clear a newer worker's stop request after an earlier worker exits" do
+      first_thread = instance_double(Thread, alive?: false)
+      second_thread = instance_double(Thread, alive?: true)
+      subject.instance_variable_set(:@thread, first_thread)
+
+      allow(Thread).to receive(:new).and_return(second_thread)
+      allow(second_thread).to receive(:report_on_exception=)
+      expect(second_thread).to receive(:join).with(Flipper::Poller::STOP_JOIN_TIMEOUT)
+      expect(first_thread).to receive(:join).with(Flipper::Poller::STOP_JOIN_TIMEOUT) do
+        subject.instance_variable_set(:@thread, nil)
+        subject.instance_variable_get(:@stop_requested).make_false
+        subject.start
+        subject.stop
+      end
+
+      subject.stop
+
+      expect(subject.thread).to be(second_thread)
+      expect(subject.instance_variable_get(:@stop_requested)).to be_true
+    end
+
+    it "clears a dead worker's stop request before starting a replacement" do
+      first_thread = instance_double(Thread, alive?: false)
+      second_thread = instance_double(Thread)
+      subject.instance_variable_set(:@thread, first_thread)
+      subject.instance_variable_get(:@stop_requested).make_true
+
+      allow(Thread).to receive(:new).and_return(second_thread)
+      allow(second_thread).to receive(:report_on_exception=)
+
+      subject.start
+
+      expect(subject.thread).to be(second_thread)
+      expect(subject.instance_variable_get(:@stop_requested)).to be_false
     end
 
     it "does not kill itself when shutdown is requested from the poller thread" do

--- a/spec/flipper/poller_spec.rb
+++ b/spec/flipper/poller_spec.rb
@@ -475,6 +475,49 @@ RSpec.describe Flipper::Poller do
 
       expect(Concurrent.monotonic_time - started_at).to be < 0.1
     end
+
+    it "keeps waiting until the deadline after a spurious wakeup" do
+      allow(subject).to receive(:wait_for_stop).and_call_original
+      allow(Concurrent).to receive(:monotonic_time).and_return(10.0, 10.0, 10.25, 11.0)
+
+      stop_mutex = subject.instance_variable_get(:@stop_mutex)
+      stop_condition = subject.instance_variable_get(:@stop_condition)
+      expect(stop_condition).to receive(:wait).with(stop_mutex, 1.0).ordered
+      expect(stop_condition).to receive(:wait).with(stop_mutex, 0.75).ordered
+
+      expect(subject.send(:wait_for_stop, 1)).to be(false)
+    end
+
+    it "wakes and joins a waiting worker, then starts a replacement" do
+      allow(Thread).to receive(:new).and_call_original
+      allow(subject).to receive(:loop).and_call_original
+      allow(subject).to receive(:wait_for_stop).and_call_original
+
+      waiting = Queue.new
+      stop_condition = subject.instance_variable_get(:@stop_condition)
+      allow(stop_condition).to receive(:wait).and_wrap_original do |original, *args|
+        waiting << true
+        original.call(*args)
+      end
+
+      subject.start
+      Timeout.timeout(5) { waiting.pop }
+      first_worker = subject.thread
+
+      subject.stop
+
+      expect(first_worker).not_to be_alive
+      expect(subject.thread).to be(nil)
+
+      subject.start
+      Timeout.timeout(5) { waiting.pop }
+      second_worker = subject.thread
+
+      expect(second_worker).not_to be(first_worker)
+      expect(second_worker).to be_alive
+    ensure
+      subject.stop
+    end
   end
 
   describe "#start" do

--- a/test_rails/system/test_help_test.rb
+++ b/test_rails/system/test_help_test.rb
@@ -30,7 +30,7 @@ end
 
 class TestHelpTest < ActionDispatch::SystemTestCase
   # Any driver that runs the app in a separate thread will test what we want here.
-  driven_by :cuprite, options: { process_timeout: 60 }
+  driven_by :cuprite, options: { process_timeout: 60, timeout: 60 }
 
   setup do
     # Reconfigure Flipper since other tests change the adapter.


### PR DESCRIPTION
## Summary
Poller shutdown now asks the worker to exit and wakes any interval wait instead of killing the thread asynchronously.
A normal stop can be followed by a clean restart, while server-driven poll-shutdown still prevents restart and avoids a worker joining itself.

## Test Plan
- `bundle exec rspec spec/flipper/poller_spec.rb`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
