### PR TITLE
Extract fork-safe mutex into ForkSafeMutex

### DIFF
--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -1,5 +1,6 @@
 require "flipper/adapter"
 require "flipper/typecast"
+require "flipper/fork_safe_mutex"
 
 module Flipper
   module Adapters
@@ -11,8 +12,7 @@ module Flipper
       # Public
       def initialize(source = nil, threadsafe: true)
         @source = Typecast.features_hash(source)
-        @lock = Mutex.new if threadsafe
-        reset
+        @lock = ForkSafeMutex.new if threadsafe
       end
 
       # Public: The set of known features.
@@ -122,18 +122,8 @@ module Flipper
 
       private
 
-      def reset
-        @pid = Process.pid
-        @lock&.unlock if @lock&.locked?
-      end
-
-      def forked?
-        @pid != Process.pid
-      end
-
       def synchronize(&block)
         if @lock
-          reset if forked?
           @lock.synchronize(&block)
         else
           block.call

--- a/lib/flipper/fork_safe_mutex.rb
+++ b/lib/flipper/fork_safe_mutex.rb
@@ -1,0 +1,56 @@
+require 'concurrent/atomic/atomic_reference'
+
+module Flipper
+  # A Mutex that is safe to use across forks. A forked child inherits a copy of
+  # the parent's mutex that may be locked by a thread which no longer exists;
+  # unlocking it would raise ThreadError. Instead of unlocking, the first use in
+  # a new process atomically swaps in a fresh mutex.
+  class ForkSafeMutex
+    State = Struct.new(:pid, :mutex)
+
+    def initialize
+      @state = Concurrent::AtomicReference.new(State.new(Process.pid, Mutex.new))
+    end
+
+    def synchronize(&block)
+      mutex.synchronize(&block)
+    end
+
+    # Public: The mutex for the current process, swapping in a fresh one if forked.
+    def mutex
+      current.mutex
+    end
+
+    def forked?
+      @state.get.pid != Process.pid
+    end
+
+    # Public: Swaps in a fresh mutex if forked. Returns true if this call
+    # observed the fork, false otherwise.
+    def reset_if_forked
+      forked = false
+      loop do
+        state = @state.get
+        return forked unless state.pid != Process.pid
+
+        forked = true
+        reset(state)
+      end
+    end
+
+    private
+
+    def current
+      loop do
+        state = @state.get
+        return state unless state.pid != Process.pid
+
+        reset(state)
+      end
+    end
+
+    def reset(expected)
+      @state.compare_and_set(expected, State.new(Process.pid, Mutex.new))
+    end
+  end
+end

--- a/lib/flipper/poller.rb
+++ b/lib/flipper/poller.rb
@@ -3,10 +3,11 @@ require 'concurrent/utility/monotonic_time'
 require 'concurrent/map'
 require 'concurrent/atomic/atomic_fixnum'
 require 'concurrent/atomic/atomic_boolean'
+require 'flipper/fork_safe_mutex'
 
 module Flipper
   class Poller
-    attr_reader :adapter, :thread, :pid, :mutex, :interval, :last_synced_at
+    attr_reader :adapter, :thread, :interval, :last_synced_at
 
     def self.instances
       @instances ||= Concurrent::Map.new
@@ -28,8 +29,7 @@ module Flipper
 
     def initialize(options = {})
       @thread = nil
-      @pid = Process.pid
-      @mutex = Mutex.new
+      @mutex = ForkSafeMutex.new
       @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
       @remote_adapter = options.fetch(:remote_adapter)
       @last_synced_at = Concurrent::AtomicFixnum.new(0)
@@ -47,7 +47,7 @@ module Flipper
     end
 
     def start
-      reset if forked?
+      @shutdown_requested.make_false if @mutex.reset_if_forked
       return if @shutdown_requested.true?
       ensure_worker_running
     end
@@ -102,16 +102,13 @@ module Flipper
       rand
     end
 
-    def forked?
-      pid != Process.pid
-    end
-
     def ensure_worker_running
       # Return early if thread is alive and avoid the mutex lock and unlock.
       return if thread_alive?
 
       # If another thread is starting worker thread, then return early so this
       # thread can enqueue and move on with life.
+      mutex = @mutex.mutex
       return unless mutex.try_lock
 
       begin
@@ -128,12 +125,6 @@ module Flipper
 
     def thread_alive?
       @thread && @thread.alive?
-    end
-
-    def reset
-      @pid = Process.pid
-      @shutdown_requested.make_false
-      mutex.unlock if mutex.locked?
     end
 
     def apply_response_headers

--- a/spec/flipper/adapters/memory_spec.rb
+++ b/spec/flipper/adapters/memory_spec.rb
@@ -33,4 +33,27 @@ RSpec.describe Flipper::Adapters::Memory do
       "following" => subject.default_config.merge(actors: Set["1", "3"], groups: Set["staff"]),
     })
   end
+
+  it "synchronizes safely after a fork" do
+    adapter = described_class.new(source, threadsafe: true)
+    fork_safe_mutex = adapter.instance_variable_get(:@lock)
+    original = fork_safe_mutex.mutex
+    locked = Queue.new
+    release = Queue.new
+    thread = Thread.new do
+      original.lock
+      locked << true
+      release.pop
+      original.unlock
+    end
+
+    locked.pop
+    allow(Process).to receive(:pid).and_return(Process.pid + 1)
+
+    expect { adapter.features }.not_to raise_error
+    expect(fork_safe_mutex.mutex).not_to equal(original)
+  ensure
+    release << true if release
+    thread&.join
+  end
 end

--- a/spec/flipper/fork_safe_mutex_spec.rb
+++ b/spec/flipper/fork_safe_mutex_spec.rb
@@ -1,0 +1,49 @@
+require "flipper/fork_safe_mutex"
+
+RSpec.describe Flipper::ForkSafeMutex do
+  subject { described_class.new }
+
+  it "synchronizes using its mutex" do
+    ran = false
+    subject.synchronize { ran = true }
+    expect(ran).to be(true)
+  end
+
+  it "is not forked within the same process" do
+    expect(subject.forked?).to be(false)
+    expect(subject.reset_if_forked).to be(false)
+  end
+
+  it "swaps in a fresh mutex after a fork instead of unlocking a stale one" do
+    original = subject.mutex
+    locked = Queue.new
+    release = Queue.new
+    thread = Thread.new do
+      original.lock
+      locked << true
+      release.pop
+      original.unlock
+    end
+
+    locked.pop
+    allow(Process).to receive(:pid).and_return(Process.pid + 1)
+
+    expect(subject.reset_if_forked).to be(true)
+    expect(subject.mutex).not_to equal(original)
+    expect { subject.synchronize {} }.not_to raise_error
+  ensure
+    release << true if release
+    thread&.join
+  end
+
+  it "keeps the winning mutex when two resets race on the same fork" do
+    stale = subject.instance_variable_get(:@state).get
+    allow(Process).to receive(:pid).and_return(stale.pid + 1)
+
+    subject.send(:reset, stale) # winner: compare_and_set against stale succeeds
+    winner = subject.mutex
+    subject.send(:reset, stale) # loser: stale is no longer current, so it's a no-op
+
+    expect(subject.mutex).to equal(winner)
+  end
+end

--- a/spec/flipper/poller_spec.rb
+++ b/spec/flipper/poller_spec.rb
@@ -356,6 +356,15 @@ RSpec.describe Flipper::Poller do
       subject.start
     end
 
+    it "swaps in a fresh mutex after a fork" do
+      fork_safe_mutex = subject.instance_variable_get(:@mutex)
+      original = fork_safe_mutex.mutex
+      allow(Process).to receive(:pid).and_return(Process.pid + 1)
+
+      expect { subject.start }.not_to raise_error
+      expect(fork_safe_mutex.mutex).not_to equal(original)
+    end
+
     context "after shutdown_requested" do
       before do
         stub_request(:get, "#{url}/features?exclude_gate_names=true")
@@ -377,7 +386,7 @@ RSpec.describe Flipper::Poller do
         subject.sync # This triggers shutdown
 
         # Simulate fork by changing PID
-        allow(Process).to receive(:pid).and_return(subject.instance_variable_get(:@pid) + 1)
+        allow(Process).to receive(:pid).and_return(Process.pid + 1)
 
         # After fork, start should work again
         expect(Thread).to receive(:new).and_yield


### PR DESCRIPTION
The `Memory` adapter and `Poller` each duplicated the same fork-detection dance: track the PID and, on first use in a forked child, unlock the inherited-but-stale mutex before locking it — which risks a `ThreadError` since the mutex may be held by a thread that no longer exists after fork.

This extracts a shared `Flipper::ForkSafeMutex` that atomically swaps in a fresh mutex on first use in a new process (via an `AtomicReference` + compare-and-set) instead of unlocking a stale one. Both `Memory` and `Poller` now delegate to it, and `Poller#start` uses the reset's return value to clear `@shutdown_requested` on fork. Added specs for the mutex, the memory adapter, and the poller cover the post-fork swap and the reset race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)