### PR TITLE
perf: Avoid enumerating the feature set repeatedly for an API request

### DIFF
--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'set'
 require 'flipper/api/error'
 require 'flipper/api/error_response'
 require 'json'
@@ -146,6 +147,21 @@ module Flipper
       end
 
       private
+
+      # Private: Does a feature with this key exist?
+      #
+      # Reads through the memoized key set below so that checking many names
+      # costs one adapter enumeration per request rather than one per name.
+      def feature_exists?(feature_name)
+        existing_feature_names.include?(feature_name)
+      end
+
+      # Private: The keys of every feature known to the adapter, read once per
+      # request. Actions are instantiated per request (see .run), so this is
+      # request scoped and cannot go stale across requests.
+      def existing_feature_names
+        @existing_feature_names ||= flipper.features.map(&:key).to_set
+      end
 
       # Private: Returns the request method converted to an action method.
       # Converts head to get.

--- a/lib/flipper/api/v1/actions/feature.rb
+++ b/lib/flipper/api/v1/actions/feature.rb
@@ -21,12 +21,6 @@ module Flipper
             flipper.remove(feature_name)
             json_response({}, 204)
           end
-
-          private
-
-          def feature_exists?(feature_name)
-            flipper.features.map(&:key).include?(feature_name)
-          end
         end
       end
     end

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -80,10 +80,6 @@ module Flipper
               values << value.to_s if Rack::Utils.unescape(key) == name
             end
           end
-
-          def feature_exists?(feature_name)
-            flipper.features.map(&:key).include?(feature_name)
-          end
         end
       end
     end

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -138,6 +138,33 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       end
     end
 
+    context 'with many requested keys' do
+      require 'flipper/adapters/operation_logger'
+
+      let(:adapter) { Flipper::Adapters::OperationLogger.new(build_memory_adapter) }
+      let(:flipper) { build_flipper(adapter) }
+
+      before do
+        flipper[:search].enable
+        flipper[:stats].enable
+        adapter.reset
+      end
+
+      it 'enumerates the feature set once regardless of how many keys are requested' do
+        get "/features?keys=#{(1..50).map { |i| "key_#{i}" }.join(',')}"
+
+        expect(last_response.status).to eq(200)
+        expect(adapter.count(:features)).to eq(1)
+      end
+
+      it 'enumerates the feature set once for repeated keys params' do
+        get "/features?#{(1..50).map { |i| "keys=key_#{i}" }.join('&')}"
+
+        expect(last_response.status).to eq(200)
+        expect(adapter.count(:features)).to eq(1)
+      end
+    end
+
     context 'with no flipper features' do
       before do
         get '/features'


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Tested and reviewed by me for correctness.

`GET /features?keys=` calls `feature_exists?` for each requested key, and each call does a full `flipper.features.map(&:key).include?(name)` — an adapter enumeration plus a `Feature` object per stored feature. The cost is the product of requested keys and stored features, and nothing bounds either.

The repeated-params form (`?keys=a&keys=b`) incurs twice the cost vs comma-separated keys: `requested_feature_names` checks each raw value for a literal comma before splitting, and `Features#get` then filters the results again.

## Fix

Memoize the key set on the action. Actions are instantiated per request (`Api::Action.run` is `new(flipper, request).run`), so the memo is request scoped and can't go stale between requests.

`feature_exists?` was defined on both `Features` and `Feature`, so this moves it to the shared `Api::Action` base class rather than duplicating the memo.

## Benchmarking

Bench'd with 100 saved features, 100 iterations each:

| features | keys | shape | stack | before | after | speedup | enumerations |
|---|---|---|---|---|---|---|---|
| 100 | 10 | comma | bare | 0.35 ms | 0.09 ms | 3.9x | 10 -> 1 |
| 100 | 10 | comma | memoizer | 0.27 ms | 0.09 ms | 3.0x | 1 -> 1 |
| 100 | 10 | repeated | bare | 0.67 ms | 0.11 ms | 6.1x | 20 -> 1 |
| 100 | 10 | repeated | memoizer | 0.50 ms | 0.11 ms | 4.5x | 1 -> 1 |
| 100 | 50 | comma | bare | 1.64 ms | 0.19 ms | 8.6x | 50 -> 1 |
| 100 | 50 | comma | memoizer | 1.26 ms | 0.19 ms | 6.6x | 1 -> 1 |
| 100 | 50 | repeated | bare | 3.16 ms | 0.31 ms | 10.2x | 100 -> 1 |
| 100 | 50 | repeated | memoizer | 2.37 ms | 0.28 ms | 8.5x | 1 -> 1 |
| 100 | 100 | comma | bare | 3.26 ms | 0.39 ms | 8.4x | 100 -> 1 |
| 100 | 100 | comma | memoizer | 2.45 ms | 0.32 ms | 7.7x | 1 -> 1 |
| 100 | 100 | repeated | bare | 6.36 ms | 0.53 ms | 12.0x | 200 -> 1 |
| 100 | 100 | repeated | memoizer | 4.80 ms | 0.48 ms | 10.0x | 1 -> 1 |

And the difference is greater in the (much less likely) case of 1000 stored features w/ 1000 requested keys:

| stack | shape | before | after |
|---|---|---|---|
| bare | comma-separated | 261 ms | 3.4 ms |
| bare | repeated params | 527 ms | 5.0 ms |
| + `Memoizer` | comma-separated | 200 ms | 2.9 ms |
| + `Memoizer` | repeated params | 402 ms | 4.5 ms |

Adapter enumerations for those requests go from 1000/2000 to 1.

`Flipper::Middleware::Memoizer` already collapsed the adapter calls to one, but not the per-key object churn — hence the memoized rows still improving in runtime. There's no case where the memo costs more than the work it replaces.