### PR TITLE
Block imports through read-only adapters

### DIFF
--- a/lib/flipper/adapters/read_only.rb
+++ b/lib/flipper/adapters/read_only.rb
@@ -4,7 +4,7 @@ module Flipper
   module Adapters
     # Public: Adapter that wraps another adapter and raises for any writes.
     class ReadOnly < Wrapper
-      WRITE_METHODS = %i[add remove clear enable disable]
+      WRITE_METHODS = %i[import add remove clear enable disable]
 
       class WriteAttempted < Error
         def initialize(message = nil)

--- a/spec/flipper/adapters/read_only_spec.rb
+++ b/spec/flipper/adapters/read_only_spec.rb
@@ -97,4 +97,14 @@ RSpec.describe Flipper::Adapters::ReadOnly do
     expect { subject.disable(feature, boolean_gate, Flipper::Types::Boolean.new) }
       .to raise_error(Flipper::Adapters::ReadOnly::WriteAttempted)
   end
+
+  it 'raises error on import without changing the wrapped adapter' do
+    adapter.add(feature)
+    source = Flipper::Adapters::Memory.new
+    source.add(Flipper::Feature.new(:replacement, source))
+
+    expect { subject.import(source) }
+      .to raise_error(Flipper::Adapters::ReadOnly::WriteAttempted)
+    expect(adapter.features).to eq(Set['stats'])
+  end
 end

--- a/spec/flipper/api/v1/actions/import_spec.rb
+++ b/spec/flipper/api/v1/actions/import_spec.rb
@@ -1,3 +1,5 @@
+require 'flipper/adapters/read_only'
+
 RSpec.describe Flipper::Api::V1::Actions::Import do
   let(:app) { build_api(flipper) }
 
@@ -95,6 +97,22 @@ RSpec.describe Flipper::Api::V1::Actions::Import do
 
       it 'does not import the features' do
         expect(flipper.features.map(&:key)).to eq([])
+      end
+    end
+
+    context 'with a read-only adapter' do
+      let(:adapter) { build_memory_adapter }
+      let(:flipper) { build_flipper(Flipper::Adapters::ReadOnly.new(adapter)) }
+
+      it 'rejects the import without changing the wrapped adapter' do
+        adapter.add(Flipper::Feature.new(:existing, adapter))
+        source_flipper = build_flipper
+        source_flipper.enable(:replacement)
+
+        expect do
+          post '/import', source_flipper.export.contents, 'CONTENT_TYPE' => 'application/json'
+        end.to raise_error(Flipper::Adapters::ReadOnly::WriteAttempted)
+        expect(adapter.features).to eq(Set['existing'])
       end
     end
   end


### PR DESCRIPTION
## Summary

- reject `import` through `Flipper::Adapters::ReadOnly` using the existing `WriteAttempted` contract
- add adapter-level regression coverage that verifies the wrapped adapter is unchanged
- add regression coverage through `Flipper::Api` `POST /import`

## Root cause

`Flipper::Adapters::Wrapper` delegates `import`, but `ReadOnly::WRITE_METHODS` omitted it. Since the wrapper refactor in 1.3.0, an import could therefore replace the wrapped adapter's complete feature set even though `read_only?` returned true.

This keeps writable adapters and other wrappers unchanged. It also preserves the existing read-only failure contract rather than adding a separate API response behavior.

## Validation

- `bundle exec rspec spec/flipper/adapters/read_only_spec.rb spec/flipper/api/v1/actions/import_spec.rb` (22 examples, 0 failures)
- `bundle exec rspec spec/flipper/adapter_spec.rb spec/flipper/adapters/read_only_spec.rb spec/flipper/adapters/memory_spec.rb spec/flipper/api` (258 examples, 0 failures)
- `git diff --check origin/main...HEAD`

No release or version changes are included.