### PR TITLE
Reject empty Flipper Cloud sync secrets

### DIFF
--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -122,7 +122,11 @@ module Flipper
       # Public: The method that will be used to synchronize local adapter with
       # cloud. (default: :poll, will be :webhook if sync_secret is non-empty).
       def sync_method
-        (sync_secret && sync_secret != "") ? :webhook : :poll
+        if !sync_secret || sync_secret.empty?
+          :poll
+        else
+          :webhook
+        end
       end
 
       # Internal: The http client used by the http adapter. Exposed so we can

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -120,9 +120,9 @@ module Flipper
       end
 
       # Public: The method that will be used to synchronize local adapter with
-      # cloud. (default: :poll, will be :webhook if sync_secret is set).
+      # cloud. (default: :poll, will be :webhook if sync_secret is non-empty).
       def sync_method
-        sync_secret ? :webhook : :poll
+        (sync_secret && sync_secret != "") ? :webhook : :poll
       end
 
       # Internal: The http client used by the http adapter. Exposed so we can

--- a/lib/flipper/cloud/message_verifier.rb
+++ b/lib/flipper/cloud/message_verifier.rb
@@ -19,6 +19,7 @@ module Flipper
         @version = version || DEFAULT_VERSION
 
         raise ArgumentError, "secret should be a string" unless @secret.is_a?(String)
+        raise ArgumentError, "secret should not be empty" if @secret.empty?
         raise ArgumentError, "version should be a string" unless @version.is_a?(String)
       end
 

--- a/lib/flipper/cloud/routes.rb
+++ b/lib/flipper/cloud/routes.rb
@@ -1,6 +1,6 @@
 # Default routes loaded by Flipper::Cloud::Engine
 Rails.application.routes.draw do
-  if ENV["FLIPPER_CLOUD_TOKEN"] && ENV["FLIPPER_CLOUD_SYNC_SECRET"]
+  if ENV["FLIPPER_CLOUD_TOKEN"] && !ENV.fetch("FLIPPER_CLOUD_SYNC_SECRET", "").empty?
     require 'flipper/cloud'
     config = Rails.application.config.flipper
 

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -172,12 +172,34 @@ RSpec.describe Flipper::Cloud::Configuration do
     expect(instance.adapter).to be_instance_of(Flipper::Adapters::DualWrite)
   end
 
+  it "sets sync_method to :poll if sync_secret is empty" do
+    instance = described_class.new(required_options.merge({
+      sync_secret: "",
+    }))
+
+    expect(instance.sync_method).to eq(:poll)
+  end
+
+  it "does not treat a whitespace sync_secret as empty" do
+    instance = described_class.new(required_options.merge(sync_secret: " "))
+
+    expect(instance.sync_secret).to eq(" ")
+    expect(instance.sync_method).to eq(:webhook)
+  end
+
   it "sets sync_method to :webhook if FLIPPER_CLOUD_SYNC_SECRET set" do
     ENV["FLIPPER_CLOUD_SYNC_SECRET"] = "abc"
     instance = described_class.new(required_options)
 
     expect(instance.sync_method).to eq(:webhook)
     expect(instance.adapter).to be_instance_of(Flipper::Adapters::DualWrite)
+  end
+
+  it "sets sync_method to :poll if FLIPPER_CLOUD_SYNC_SECRET is empty" do
+    ENV["FLIPPER_CLOUD_SYNC_SECRET"] = ""
+    instance = described_class.new(required_options)
+
+    expect(instance.sync_method).to eq(:poll)
   end
 
   it "can set sync_secret" do

--- a/spec/flipper/cloud/message_verifier_spec.rb
+++ b/spec/flipper/cloud/message_verifier_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Flipper::Cloud::MessageVerifier do
   let(:secret) { "secret" }
   let(:timestamp) { Time.now }
 
+  it "rejects an empty secret" do
+    expect {
+      described_class.new(secret: "")
+    }.to raise_error(ArgumentError, "secret should not be empty")
+  end
+
   describe "#generate" do
     it "generates signature that can be verified" do
       message_verifier = Flipper::Cloud::MessageVerifier.new(secret: secret)

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Flipper::Cloud::Middleware do
     Flipper::Cloud::MessageVerifier.new(secret: flipper.sync_secret).generate(request_body, timestamp)
   }
   let(:signature_header_value) {
-    Flipper::Cloud::MessageVerifier.new(secret: "").header(signature, timestamp)
+    Flipper::Cloud::MessageVerifier.header(signature, timestamp)
   }
 
   context 'when initializing middleware with flipper instance' do

--- a/spec/flipper/engine_spec.rb
+++ b/spec/flipper/engine_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Flipper::Engine do
         Flipper::Cloud::MessageVerifier.new(secret: ENV["FLIPPER_CLOUD_SYNC_SECRET"]).generate(request_body, timestamp)
       }
       let(:signature_header_value) {
-        Flipper::Cloud::MessageVerifier.new(secret: "").header(signature, timestamp)
+        Flipper::Cloud::MessageVerifier.header(signature, timestamp)
       }
 
       it "configures webhook app and uses cache busting" do
@@ -288,6 +288,19 @@ RSpec.describe Flipper::Engine do
     end
 
     context "without CLOUD_SYNC_SECRET" do
+      it "does not configure webhook app" do
+        silence { application.initialize! }
+
+        post "/_flipper"
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context "with empty CLOUD_SYNC_SECRET" do
+      before do
+        ENV["FLIPPER_CLOUD_SYNC_SECRET"] = ""
+      end
+
       it "does not configure webhook app" do
         silence { application.initialize! }
 


### PR DESCRIPTION
## Summary

- treat an empty Cloud sync secret as absent and fall back to polling
- do not mount the Rails webhook route when `FLIPPER_CLOUD_SYNC_SECRET` is empty
- reject direct `MessageVerifier` construction with an empty secret
- preserve non-empty secrets exactly, including whitespace-only values

## Why

Ruby treats an empty string as truthy. That caused an empty sync secret to select webhook mode and mount the webhook endpoint. The verifier also accepted the empty string as an HMAC key, so this misconfiguration did not fail closed.

The checks are intentionally limited to the exact empty string. Existing non-empty secret behavior is unchanged.

## Validation

- `bundle exec rspec spec/flipper/cloud/configuration_spec.rb spec/flipper/cloud/message_verifier_spec.rb spec/flipper/cloud/middleware_spec.rb spec/flipper/engine_spec.rb` — 103 examples, 0 failures
- `bundle exec rspec spec/flipper/cloud_spec.rb spec/flipper/cloud` — 145 examples, 0 failures
- focused post-commit security regressions — 9 examples, 0 failures

No VERSION, CHANGELOG, or release files are changed; this is intended to ship with Flipper 1.5.