### PR TITLE
Allow explicit feature creation in strict mode

### DIFF
--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -191,7 +191,7 @@ module Flipper
     #
     # Returns result of add.
     def add(name)
-      feature(name).add
+      Adapters::Strict.with_sync_mode { feature(name).add }
     end
 
     # Public: Has a feature been added in the adapter.

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -309,6 +309,19 @@ RSpec.describe Flipper::DSL do
       subject.add(:stats)
       expect(subject.features).to eq(Set[subject[:stats]])
     end
+
+    context 'with a strict adapter' do
+      let(:adapter) { Flipper::Adapters::Strict.new(Flipper::Adapters::Memory.new, :raise) }
+
+      it 'adds a new feature without triggering a strict check' do
+        expect { subject.add(:stats) }.not_to raise_error
+        expect(subject.exist?(:stats)).to be(true)
+      end
+
+      it 'continues enforcing strict checks outside of explicit adds' do
+        expect { subject.enable(:stats) }.to raise_error(Flipper::Adapters::Strict::NotFound)
+      end
+    end
   end
 
   describe '#exist?' do


### PR DESCRIPTION
Fixes #1026

## Summary

- let explicit `Flipper.add` calls use the strict adapter's existing scoped check bypass
- keep strict checks active for implicit feature creation through operations such as `enable`
- add regression coverage for both behaviors

## Test plan

- `bundle exec rspec spec/flipper/dsl_spec.rb spec/flipper/adapters/strict_spec.rb`
- core RSpec suite excluding service/socket/terminal-dependent files (2,595 examples, 0 failures)
- core Minitest suite excluding Redis-dependent files (242 runs, 4,636 assertions, 0 failures)
- Rails generator and helper tests (14 runs, 111 assertions, 0 failures)
- `bundle exec rake build`
