### PR TITLE
Strip additional invisible characters from feature names

### DIFF
--- a/lib/flipper/typecast.rb
+++ b/lib/flipper/typecast.rb
@@ -81,9 +81,10 @@ module Flipper
     #
     # Returns a String.
     def self.to_feature_name(value)
+      # U+2800 renders as a fixed-width blank but is not default-ignorable or whitespace.
       value.to_s
            .scrub('')
-           .gsub(/[\p{Cf}\p{Cc}]/, '')
+           .gsub(/[\p{Default_Ignorable_Code_Point}\p{Cc}\u2800]/, '')
            .gsub(/\A[[:space:]]+|[[:space:]]+\z/, '')
     end
 

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
 
     context 'feature name contains invisible characters' do
       before do
-        post '/features', name: "my_\u200Bfeature\u2060"
+        post '/features', name: "my_\u3164\u115Ffeature\u1160\uFFA0\u2800\u17B4"
       end
 
       it 'responds 200' do
@@ -310,7 +310,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
 
     context 'feature name normalizes to empty' do
       before do
-        post '/features', name: "\u200B\u2060"
+        post '/features', name: "\u3164\u115F\u1160\uFFA0\u2800\u17B4"
       end
 
       it 'returns correct status code' do

--- a/spec/flipper/typecast_spec.rb
+++ b/spec/flipper/typecast_spec.rb
@@ -231,6 +231,25 @@ RSpec.describe Flipper::Typecast do
       expect(described_class.to_feature_name("feat\u0000ure")).to eq("feature")
     end
 
+    it "removes default-ignorable fillers and other blank characters" do
+      invisible_characters = {
+        "hangul filler" => "\u3164",
+        "hangul choseong filler" => "\u115F",
+        "hangul jungseong filler" => "\u1160",
+        "halfwidth hangul filler" => "\uFFA0",
+        "braille pattern blank" => "\u2800",
+        "khmer vowel inherent aq" => "\u17B4",
+      }
+
+      invisible_characters.each do |name, character|
+        expect(described_class.to_feature_name("fea#{character}ture")).to eq("feature"), name
+      end
+    end
+
+    it "keeps non-default-ignorable format characters" do
+      expect(described_class.to_feature_name("\u06DDfeature")).to eq("\u06DDfeature")
+    end
+
     it "trims unicode whitespace" do
       expect(described_class.to_feature_name("\u00A0feature\u3000")).to eq("feature")
       expect(described_class.to_feature_name("  feature  ")).to eq("feature")

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Flipper::UI::Actions::Features do
       end
 
       context 'feature name contains accented and invisible characters' do
-        let(:feature_name) { "f\u200Be\u00E1\u2060ture" }
+        let(:feature_name) { "f\u3164e\u115F\u00E1\u1160t\uFFA0u\u2800r\u17B4e" }
 
         it 'adds feature with invisible characters removed and accent kept' do
           expect(flipper.features.map(&:key)).to include("fe\u00E1ture")
@@ -252,7 +252,7 @@ RSpec.describe Flipper::UI::Actions::Features do
         end
 
         context 'feature name that normalizes to empty' do
-          let(:feature_name) { "\u200B\u2060" }
+          let(:feature_name) { "\u3164\u115F\u1160\uFFA0\u2800\u17B4" }
 
           it 'does not add feature' do
             expect(flipper.features.map(&:key)).to eq([])


### PR DESCRIPTION
Follow-up to #1033 and https://github.com/flippercloud/flipper/pull/1033#issuecomment-5309404007.

## Summary

- strip Unicode default-ignorable code points from feature names, covering Hangul fillers and the Khmer inherent vowel character reported after #1033
- explicitly strip U+2800 BRAILLE PATTERN BLANK, which renders blank but is neither default-ignorable nor Unicode whitespace
- preserve visible format characters and retain the existing control-character and Unicode-whitespace behavior
- cover normalization through core, API, and UI feature creation

## Testing

- `bundle exec rspec spec/flipper/typecast_spec.rb spec/flipper/api/v1/actions/features_spec.rb spec/flipper/ui/actions/features_spec.rb` (111 examples, 0 failures)
- Ruby 2.6.10 smoke test for the updated Unicode property regex and all six reported code points
