### PR TITLE
Fix API parsing of empty query segments

### DIFF
--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -76,6 +76,8 @@ module Flipper
 
           def raw_query_values(name)
             request.query_string.to_s.split(/[&;]/).each_with_object([]) do |part, values|
+              next if part.empty?
+
               key, value = part.split('=', 2)
               values << value.to_s if Rack::Utils.unescape(key) == name
             end

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -79,6 +79,26 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
         expect(last_response.status).to eq(200)
         expect(json_response).to eq(expected_response)
       end
+
+      it 'ignores a leading empty query segment' do
+        get '/features?exclude_gate_names=true'
+        expected_response = json_response
+
+        get '/features?&exclude_gate_names=true'
+
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(expected_response)
+      end
+
+      it 'ignores consecutive and trailing empty query segments' do
+        get '/features?exclude_gate_names=true'
+        expected_response = json_response
+
+        get '/features?&&exclude_gate_names=true&&;'
+
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(expected_response)
+      end
     end
 
     context 'with keys specified' do


### PR DESCRIPTION
## Summary

- Ignore empty query-string segments before decoding raw feature-query keys.
- Prevent `/features?&exclude_gate_names=true` and equivalent separator patterns from raising while preserving the normal all-features response.
- Keep the custom encoded-comma behavior intact and add focused regression coverage for leading, consecutive, and trailing separators.

## Test Coverage

```text
CODE PATHS                                                   USER FLOWS
[+] GET /features                                            [+] Cached feature polling
  └── requested_feature_names                                  ├── [★★  TESTED] Normal all-features response
      └── raw_query_values("keys")                             │   features_spec.rb:60
          ├── [★★★ TESTED] Empty segment → skip                 ├── [★★★ TESTED] Leading `&` returns 200 and the
          │   features_spec.rb:83,93                            │   normal all-features response — :83
          ├── [★★★ TESTED] Non-empty unrelated segment          └── [★★★ TESTED] Consecutive/trailing separators
          │   → unescape key, do not collect value                  return the same response — :93
          │   features_spec.rb:83,93
          ├── [★★  TESTED] Matching `keys` segment             [+] Encoded-comma compatibility
          │   → preserve raw value                              ├── [★★★ TESTED] Array key containing `%2C` — :120
          │   features_spec.rb:120,134                          └── [★★★ TESTED] Single key containing `%2C` — :134
          └── [★★★ TESTED] No requested keys
              → decoded_feature_names → nil
              → flipper.features (all features)
              features_spec.rb:83,93

COVERAGE: 9/9 paths tested (100%)  |  Code paths: 5/5 (100%)  |  User flows: 4/4 (100%)
QUALITY: ★★★:7 ★★:2 ★:0  |  GAPS: 0  |  E2E: not needed; Rack request specs exercise the API boundary
```

Legend: ★★★ behavior + edge/error path | ★★ correct behavior | ★ smoke check

## Pre-Landing Review

No issues found. The guard affects only empty segments, uses Ruby 2.6-compatible syntax, and leaves non-empty raw values on the existing decoding path.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN

## Plan Completion

No plan file detected; plan completion audit skipped.

## Verification Results

No plan verification steps were applicable.

## Test plan

- [x] `bundle exec rspec spec/flipper/api/v1/actions/features_spec.rb` — 22 examples, 0 failures
- [x] `bundle exec rspec spec/flipper/api/v1/actions` — 144 examples, 0 failures
- [x] `bundle exec rspec spec/flipper/adapters/http_spec.rb` — 100 examples, 0 failures
- [x] `env -u NO_COLOR TERM=xterm bundle exec rspec` — 2,963 examples, 0 failures, 2 expected pending

Generated with [OpenAI Codex](https://openai.com/codex/).
