### PR TITLE
Harden API read parameter parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,25 @@ name: CI
 on: [push]
 
 jobs:
+  rack-2-minimum:
+    name: Test flipper-api on Rack 2.0.9.4
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v7
+      - name: Set up Ruby 2.6
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: Install focused dependencies
+        run: |
+          gem install concurrent-ruby --version '< 2' --no-document
+          gem install minitest --version '5.15.0' --no-document
+          gem install rack --version '2.0.9.4' --no-document
+      - name: Run Rack 2.0.9.4 compatibility test
+        run: ruby -Ilib spec/flipper/api/rack_2_compatibility_test.rb
+
   test:
     name: Test on ruby ${{ matrix.ruby }} and rails ${{ matrix.rails }}
     runs-on: ubuntu-latest

--- a/flipper-api.gemspec
+++ b/flipper-api.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
   gem.version       = Flipper::VERSION
   gem.metadata      = Flipper::METADATA
 
-  gem.add_dependency 'rack', '>= 1.4', '< 4'
+  gem.add_dependency 'rack', '>= 2', '< 4'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
 end

--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -192,11 +192,17 @@ module Flipper
         parsers = [Rack::Utils]
         parsers << Rack.const_get(:QueryParser, false) if Rack.const_defined?(:QueryParser, false)
         error_names = [:InvalidParameterError, :ParameterTypeError, :ParamsTooDeepError, :QueryLimitError]
-        parsers.each_with_object([]) do |parser, errors|
+        errors = parsers.each_with_object([]) do |parser, result|
           error_names.each do |name|
-            errors << parser.const_get(name, false) if parser.const_defined?(name, false)
+            result << parser.const_get(name, false) if parser.const_defined?(name, false)
           end
-        end.uniq
+        end
+        has_named_depth_error = parsers.any? do |parser|
+          parser.const_defined?(:ParamsTooDeepError, false)
+        end
+        # Rack 2.0 reports nesting and key-space limits as plain RangeError.
+        errors << RangeError unless has_named_depth_error
+        errors.uniq
       end
 
       # Private: Returns the request method converted to an action method.

--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -163,6 +163,42 @@ module Flipper
         @existing_feature_names ||= flipper.features.map(&:key).to_set
       end
 
+      # Private: Returns request parameters, or an empty hash when Rack cannot
+      # parse client-controlled parameter syntax.
+      def safe_params
+        @safe_params ||= params
+      rescue *parameter_parser_errors
+        @params_parse_failed = true
+        @safe_params = {}
+      end
+
+      def params_parse_failed?
+        safe_params
+        @params_parse_failed == true
+      end
+
+      # Private: Returns a valid String parameter, ignoring other shapes and
+      # invalid encodings.
+      def string_param(name)
+        value = safe_params[name]
+        value if valid_param_string?(value)
+      end
+
+      def valid_param_string?(value)
+        value.is_a?(String) && value.valid_encoding?
+      end
+
+      def parameter_parser_errors
+        parsers = [Rack::Utils]
+        parsers << Rack.const_get(:QueryParser, false) if Rack.const_defined?(:QueryParser, false)
+        error_names = [:InvalidParameterError, :ParameterTypeError, :ParamsTooDeepError, :QueryLimitError]
+        parsers.each_with_object([]) do |parser, errors|
+          error_names.each do |name|
+            errors << parser.const_get(name, false) if parser.const_defined?(name, false)
+          end
+        end.uniq
+      end
+
       # Private: Returns the request method converted to an action method.
       # Converts head to get.
       def request_method_name

--- a/lib/flipper/api/v1/actions/actors.rb
+++ b/lib/flipper/api/v1/actions/actors.rb
@@ -9,7 +9,7 @@ module Flipper
           route %r{\A/actors/(?<flipper_id>.*)/?\Z}
 
           def get
-            keys = params['keys']
+            keys = string_param('keys')
             features = if keys
                          names = keys.split(',')
                          if names.empty?

--- a/lib/flipper/api/v1/actions/feature.rb
+++ b/lib/flipper/api/v1/actions/feature.rb
@@ -12,7 +12,7 @@ module Flipper
 
           def get
             return json_error_response(:feature_not_found) unless feature_exists?(feature_name)
-            exclude_gates = params['exclude_gates']&.downcase == "true"
+            exclude_gates = string_param('exclude_gates')&.downcase == "true"
             feature = Decorators::Feature.new(flipper[feature_name])
             json_response(feature.as_json(exclude_gates: exclude_gates))
           end

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -51,10 +51,13 @@ module Flipper
           private
 
           def requested_feature_names
-            keys = safe_params['keys']
-            return nil unless keys
+            request_params = safe_params
+            return nil unless request_params.key?('keys')
+
+            keys = request_params['keys']
+            return [] if keys.nil?
             return nil unless valid_feature_keys?(keys)
-            return keys if keys.is_a?(Array)
+            return keys.map { |key| key || '' } if keys.is_a?(Array)
 
             raw_keys = raw_query_values("keys")
             return nil unless raw_keys
@@ -102,7 +105,7 @@ module Flipper
           def valid_feature_keys?(keys)
             return valid_param_string?(keys) unless keys.is_a?(Array)
 
-            keys.all? { |key| valid_param_string?(key) }
+            keys.all? { |key| key.nil? || valid_param_string?(key) }
           end
 
           def decoded_query_component(value)

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -10,8 +10,8 @@ module Flipper
 
           def get
             names = requested_feature_names
-            exclude_gates = params['exclude_gates']&.downcase == "true"
-            exclude_gate_names = params['exclude_gate_names']&.downcase == "true"
+            exclude_gates = query_string_param('exclude_gates')&.downcase == "true"
+            exclude_gate_names = query_string_param('exclude_gate_names')&.downcase == "true"
 
             features = if names
               if names.empty?
@@ -51,10 +51,13 @@ module Flipper
           private
 
           def requested_feature_names
-            keys = params['keys']
-            return keys.map(&:to_s) if keys.is_a?(Array)
+            keys = safe_params['keys']
+            return nil unless keys
+            return nil unless valid_feature_keys?(keys)
+            return keys if keys.is_a?(Array)
 
             raw_keys = raw_query_values("keys")
+            return nil unless raw_keys
             return decoded_feature_names if raw_keys.empty?
 
             raw_keys.flat_map do |keys|
@@ -68,19 +71,45 @@ module Flipper
           end
 
           def decoded_feature_names
-            keys = params['keys']
-            return nil unless keys
-
-            Array(keys).flat_map { |key| key.to_s.split(',') }
+            safe_params['keys'].split(',')
           end
 
           def raw_query_values(name)
-            request.query_string.to_s.split(/[&;]/).each_with_object([]) do |part, values|
+            values = []
+            request.query_string.to_s.split(/[&;]/).each do |part|
               next if part.empty?
 
               key, value = part.split('=', 2)
-              values << value.to_s if Rack::Utils.unescape(key) == name
+              decoded_key = decoded_query_component(key)
+              return nil unless decoded_key
+              next unless decoded_key == name
+              return nil unless decoded_query_component(value.to_s)
+
+              values << value.to_s
             end
+            values
+          end
+
+          def query_string_param(name)
+            value = string_param(name)
+            return value if value || safe_params.key?(name)
+            return nil if params_parse_failed?
+
+            raw_values = raw_query_values(name)
+            Rack::Utils.unescape(raw_values.last) if raw_values && !raw_values.empty?
+          end
+
+          def valid_feature_keys?(keys)
+            return valid_param_string?(keys) unless keys.is_a?(Array)
+
+            keys.all? { |key| valid_param_string?(key) }
+          end
+
+          def decoded_query_component(value)
+            decoded = Rack::Utils.unescape(value)
+            decoded if decoded.valid_encoding?
+          rescue ArgumentError
+            nil
           end
         end
       end

--- a/spec/flipper/api/action_spec.rb
+++ b/spec/flipper/api/action_spec.rb
@@ -116,5 +116,13 @@ RSpec.describe Flipper::Api::Action do
 
       expect { action.send(:safe_params) }.to raise_error(ArgumentError, 'application failure')
     end
+
+    it 'does not classify unrelated range errors on modern Rack as parameter errors' do
+      request = double('Request', request_method: 'GET')
+      allow(request).to receive(:params).and_raise(RangeError, 'application failure')
+      action = action_subclass.new(flipper, request)
+
+      expect { action.send(:safe_params) }.to raise_error(RangeError, 'application failure')
+    end
   end
 end

--- a/spec/flipper/api/action_spec.rb
+++ b/spec/flipper/api/action_spec.rb
@@ -107,4 +107,14 @@ RSpec.describe Flipper::Api::Action do
       end
     end
   end
+
+  describe 'safe parameters' do
+    it 'does not classify unrelated application errors as parameter errors' do
+      request = double('Request', request_method: 'GET')
+      allow(request).to receive(:params).and_raise(ArgumentError, 'application failure')
+      action = action_subclass.new(flipper, request)
+
+      expect { action.send(:safe_params) }.to raise_error(ArgumentError, 'application failure')
+    end
+  end
 end

--- a/spec/flipper/api/rack_2_compatibility_test.rb
+++ b/spec/flipper/api/rack_2_compatibility_test.rb
@@ -1,0 +1,45 @@
+$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+
+require 'json'
+require 'minitest/autorun'
+require 'pathname'
+require 'rack/mock'
+require 'flipper'
+require 'flipper/api'
+
+class Rack2CompatibilityTest < Minitest::Test
+  MALFORMED_QUERIES = {
+    'malformed percent escape' => 'keys=%',
+    'conflicting parameter shapes' => 'a=1&a[]=2',
+    'excessive nesting' => "a#{'[a]' * 150}=1",
+  }.freeze
+
+  def setup
+    flipper = Flipper.new(Flipper::Adapters::Memory.new)
+    flipper[:my_feature].enable
+    @app = Flipper::Api.app(flipper)
+  end
+
+  def test_rack_2_parser_failures_fail_open
+    assert_equal '2.0.9.4', Rack.release
+    expected_response = raw_get('')
+
+    MALFORMED_QUERIES.each do |description, query|
+      response = raw_get(query)
+
+      assert_equal 200, response.first, description
+      assert_equal expected_response, response, description
+    end
+  end
+
+  private
+
+  def raw_get(query_string)
+    env = Rack::MockRequest.env_for('/features', 'QUERY_STRING' => query_string)
+    status, headers, body = @app.call(env)
+    response_body = body.each_with_object(+'') { |part, buffer| buffer << part }
+    [status, headers, JSON.parse(response_body)]
+  ensure
+    body.close if body.respond_to?(:close)
+  end
+end

--- a/spec/flipper/api/v1/actions/actors_spec.rb
+++ b/spec/flipper/api/v1/actions/actors_spec.rb
@@ -9,6 +9,27 @@ RSpec.describe Flipper::Api::V1::Actions::Actors do
       flipper[:my_feature_3].enable_actor(actor)
     end
 
+    malformed_queries = {
+      'array-shaped keys' => 'keys[]=my_feature_1',
+      'hash-shaped keys' => 'keys[a]=my_feature_1',
+      'a bare percent escape' => 'keys=%',
+      'an invalid percent escape' => 'keys=%GG',
+      'invalid UTF-8' => 'keys=%FF',
+      'conflicting parameter shapes' => 'a=1&a[]=2',
+      'excessive nesting' => "a#{'[a]' * 150}=1",
+    }
+
+    malformed_queries.each do |description, query|
+      it "ignores #{description}" do
+        expected_response = raw_api_get("/actors/#{actor.flipper_id}", '')
+
+        response = raw_api_get("/actors/#{actor.flipper_id}", query)
+
+        expect(response.first).to eq(200)
+        expect(response).to eq(expected_response)
+      end
+    end
+
     context 'when no feature is specified' do
       before do
         get "/actors/#{actor.flipper_id}"

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -4,6 +4,40 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
   let(:gate) { feature.gate(:boolean) }
 
   describe 'get' do
+    malformed_queries = {
+      'array-shaped exclude_gates' => 'exclude_gates[]=true',
+      'hash-shaped exclude_gates' => 'exclude_gates[a]=true',
+      'a bare percent escape' => 'exclude_gates=%',
+      'an invalid percent escape' => 'exclude_gates=%GG',
+      'invalid UTF-8' => 'exclude_gates=%FF',
+      'conflicting parameter shapes' => 'a=1&a[]=2',
+      'excessive nesting' => "a#{'[a]' * 150}=1",
+    }
+
+    malformed_queries.each do |description, query|
+      it "ignores #{description}" do
+        flipper[:my_feature].enable
+        expected_response = raw_api_get('/features/my_feature', '')
+
+        response = raw_api_get('/features/my_feature', query)
+
+        expect(response.first).to eq(200)
+        expect(response).to eq(expected_response)
+      end
+    end
+
+    it 'responds without gates when instructed by param' do
+      flipper[:my_feature].enable
+
+      status, _, body = raw_api_get('/features/my_feature', 'exclude_gates=true')
+
+      expect(status).to eq(200)
+      expect(body).to eq(
+        'key' => 'my_feature',
+        'state' => 'on'
+      )
+    end
+
     context 'enabled feature' do
       before do
         flipper[:my_feature].enable

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -84,6 +84,8 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       'keys=my_feature&keys=other_feature' => %w[my_feature other_feature],
       'keys=&keys=my_feature' => %w[my_feature],
       '=&keys=my_feature&=value' => %w[my_feature],
+      'keys' => [],
+      'keys[]' => [],
       'keys=' => [],
     }.each do |query, expected_keys|
       it "preserves duplicate and blank parameter semantics for #{query.inspect}" do

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -4,6 +4,100 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
   let(:admin) { double 'Fake Fliper Thing', flipper_id: 10 }
 
   describe 'get' do
+    malformed_queries = {
+      'array-shaped exclude_gate_names' => 'exclude_gate_names[]=true',
+      'hash-shaped exclude_gates' => 'exclude_gates[a]=true',
+      'hash-shaped keys' => 'keys[a]=my_feature',
+      'nested array-shaped keys' => 'keys[][]=my_feature',
+      'a bare percent escape' => 'keys=%',
+      'a truncated percent escape' => 'keys=%2',
+      'an invalid percent escape in a value' => 'keys=%GG',
+      'an invalid percent escape in a key' => '%GG=value',
+      'invalid UTF-8 in a key' => '%FF=value&keys=my_feature',
+      'invalid UTF-8' => 'keys=%FF',
+      'conflicting parameter shapes' => 'a=1&a[]=2',
+      'excessive nesting' => "a#{'[a]' * 150}=1",
+      'excessive parameter count' => (1..5000).map { |index| "ignored#{index}=1" }.join('&'),
+    }
+
+    malformed_queries.each do |description, query|
+      it "fails open for #{description}" do
+        flipper[:my_feature].enable
+        expected_response = raw_api_get('/features', '')
+
+        response = raw_api_get('/features', query)
+
+        expect(response.first).to eq(200)
+        expect(response).to eq(expected_response)
+      end
+    end
+
+    it 'fully fails open when malformed syntax is combined with a valid option' do
+      flipper[:my_feature].enable
+      expected_response = raw_api_get('/features', '')
+
+      response = raw_api_get('/features', 'a=1&a[]=2&exclude_gate_names=true')
+
+      expect(response.first).to eq(200)
+      expect(response).to eq(expected_response)
+    end
+
+    separator_queries = [
+      '&exclude_gate_names=true',
+      '&&exclude_gate_names=true&&',
+      ';exclude_gate_names=true',
+      ';;exclude_gate_names=true;;',
+      'exclude_gate_names=true&&;;',
+    ]
+
+    separator_queries.each do |query|
+      it "preserves optional parameter semantics with empty query segments in #{query.inspect}" do
+        flipper[:my_feature].enable
+        expected_response = raw_api_get('/features', 'exclude_gate_names=true')
+
+        response = raw_api_get('/features', query)
+
+        expect(response.first).to eq(200)
+        expect(response).to eq(expected_response)
+      end
+    end
+
+    it 'fails open when decoding a raw query component raises ArgumentError' do
+      request = instance_double(Rack::Request, query_string: 'keys=%')
+      action = described_class.new(flipper, request)
+      allow(action).to receive(:safe_params).and_return('keys' => 'my_feature')
+      allow(Rack::Utils).to receive(:unescape).with('keys').and_return('keys')
+      allow(Rack::Utils).to receive(:unescape).with('%').and_raise(ArgumentError)
+
+      expect(action.send(:requested_feature_names)).to be_nil
+    end
+
+    it 'uses parsed keys when no raw keys parameter is present' do
+      request = instance_double(Rack::Request, query_string: 'other=value')
+      action = described_class.new(flipper, request)
+      allow(action).to receive(:safe_params).and_return('keys' => 'my_feature,other_feature')
+
+      expect(action.send(:requested_feature_names)).to eq(%w[my_feature other_feature])
+    end
+
+    {
+      'keys=my_feature&keys=other_feature' => %w[my_feature other_feature],
+      'keys=&keys=my_feature' => %w[my_feature],
+      '=&keys=my_feature&=value' => %w[my_feature],
+      'keys=' => [],
+    }.each do |query, expected_keys|
+      it "preserves duplicate and blank parameter semantics for #{query.inspect}" do
+        flipper[:my_feature].enable
+        flipper[:other_feature].disable
+
+        status, _, body = raw_api_get('/features', query)
+        keys = body.fetch('features').map { |feature| feature.fetch('key') }.sort
+
+        expect(status).to eq(200)
+        expect(keys).to eq(expected_keys.sort)
+      end
+    end
+
     context 'with flipper features' do
       before do
         flipper[:my_feature].enable
@@ -78,6 +172,20 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
         get '/features', 'exclude_gate_names' => 'true'
         expect(last_response.status).to eq(200)
         expect(json_response).to eq(expected_response)
+      end
+
+      it 'responds without gates when instructed by param' do
+        get '/features', 'exclude_gates' => 'true'
+
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(
+          'features' => [
+            {
+              'key' => 'my_feature',
+              'state' => 'on',
+            },
+          ]
+        )
       end
 
       it 'ignores a leading empty query segment' do

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -37,6 +37,15 @@ module SpecHelpers
     JSON.parse(body)
   end
 
+  def raw_api_get(path, query_string)
+    env = Rack::MockRequest.env_for(path, 'QUERY_STRING' => query_string)
+    status, headers, body = app.call(env)
+    response_body = body.each_with_object(+'') { |part, buffer| buffer << part }
+    [status, headers, JSON.parse(response_body)]
+  ensure
+    body.close if body.respond_to?(:close)
+  end
+
   def api_error_code_reference_url
     'https://flippercloud.io/docs/api#error-code-reference'
   end


### PR DESCRIPTION
## Summary

- Fail open to the normal all-features response when known Rack query parser, encoding, or parameter-shape failures affect API read requests.
- Validate optional scalar parameters on feature and actor reads without changing valid request semantics, including encoded-comma keys, bare `keys` selectors, and empty `&`/`;` segments.
- Add deterministic regression coverage for malformed escapes, invalid UTF-8, conflicting/nested/oversized parameter shapes, duplicates, blanks, and supported Rack 2/Rack 3 behavior.
- Correct `flipper-api`'s Rack dependency floor from Rack 1.4 to Rack 2 and continuously test the Rack 2.0 boundary. Current API response handling has required Rack 2 header constants since 2023.

This is the read-path hardening follow-up to #1044. It does not change write endpoints.

## Failure-first evidence

Before the implementation changes, the new focused corpus produced:

- Rack 2.2.10: 69 examples, 24 failures
- Rack 3.0.9.1: 69 examples, 24 failures

Review follow-up regressions also failed before their fixes:

- Bare `keys` and `keys[]`: 50 examples, 2 failures
- Rack 2.0.9.4 excessive nesting: 1 error from the parser's plain `RangeError`

Valid compatibility cases, including encoded commas, remained green.

## Test plan

- Ruby 2.6 / Rack 2.0.9.4 compatibility lane: 1 run, 7 assertions, 0 failures
- Rack 2.2.23 focused API actions: 90 examples, 0 failures
- Rack 3.0.9.1 focused API actions: 90 examples, 0 failures
- Rack 3.2.7 focused API actions: 90 examples, 0 failures
- Nearby API suite on the default Rack 2 bundle: 209 examples, 0 failures
- Full suite on the default Rack 2 bundle: 3008 examples, 0 failures, 2 expected SQLite role pendings
- Ruby syntax checks for all changed Ruby files: Syntax OK
- GitHub Actions workflow YAML: parsed successfully
- `flipper-api` Rack requirement: `>= 2, < 4`
- `git diff --check`: clean

Independent changed-path audit: 100%, 0 scoped gaps before the review follow-up; the follow-up adds direct regressions for both reported risks.
