### PR TITLE
Load cloud migration support in UI action

### DIFF
--- a/lib/flipper/ui/actions/cloud_migrate.rb
+++ b/lib/flipper/ui/actions/cloud_migrate.rb
@@ -1,5 +1,6 @@
 require 'flipper/ui/action'
 require 'flipper/ui/util'
+require 'flipper/cloud/migrate'
 
 module Flipper
   module UI

--- a/spec/flipper/cloud/telemetry_spec.rb
+++ b/spec/flipper/cloud/telemetry_spec.rb
@@ -128,9 +128,10 @@ RSpec.describe Flipper::Cloud::Telemetry do
 
   it "doesn't try to update telemetry interval from error if not response error" do
     stub = stub_request(:post, "https://www.flippercloud.io/adapter/telemetry").
+      with(headers: {"flipper-cloud-token" => "non-response-error-test"}).
       to_raise(Net::OpenTimeout)
 
-    cloud_configuration = Flipper::Cloud::Configuration.new(token: "test")
+    cloud_configuration = Flipper::Cloud::Configuration.new(token: "non-response-error-test")
     telemetry = described_class.new(cloud_configuration)
 
     # Override the submitter to use back off policy that doesn't actually

--- a/spec/flipper/ui/actions/cloud_migrate_spec.rb
+++ b/spec/flipper/ui/actions/cloud_migrate_spec.rb
@@ -1,5 +1,3 @@
-require 'flipper/cloud/migrate'
-
 RSpec.describe Flipper::UI::Actions::CloudMigrate do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)


### PR DESCRIPTION
## Summary

- load `flipper/cloud/migrate` from the UI cloud migration action
- stop the action spec from preloading the production dependency
- preserve isolated coverage so missing production requires fail in a fresh Ruby process

## Testing

- `bundle exec rspec spec/flipper/ui/actions/cloud_migrate_spec.rb`