### PR TITLE
Preserve wrapped adapter import semantics through caches

### DIFF
--- a/lib/flipper/adapters/cache_base.rb
+++ b/lib/flipper/adapters/cache_base.rb
@@ -99,6 +99,19 @@ module Flipper
       end
 
       # Public
+      def import(source)
+        feature_keys = @adapter.features
+        result = @adapter.import(source)
+        return result unless result
+
+        feature_keys |= @adapter.features
+
+        feature_keys.each { |key| cache_delete feature_cache_key(key) }
+        expire_features_cache
+        result
+      end
+
+      # Public
       def enable(feature, gate, thing)
         result = @adapter.enable(feature, gate, thing)
         expire_feature_cache(feature.key)

--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -280,6 +280,70 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
     end
   end
 
+  describe '#import' do
+    it "delegates to the wrapped adapter's import" do
+      source = Flipper::Adapters::Memory.new
+      result = Object.new
+      expect(memory_adapter).to receive(:import).with(source).and_return(result)
+
+      expect(adapter.import(source)).to be(result)
+    end
+
+    it 'expires caches for changed, added, and removed features' do
+      flipper[:changed].add
+      flipper[:removed].enable
+
+      source_adapter = Flipper::Adapters::Memory.new
+      source_flipper = Flipper.new(source_adapter)
+      source_flipper[:changed].enable
+      source_flipper[:added].enable
+
+      [:changed, :added, :removed].each { |key| adapter.get(flipper[key]) }
+      adapter.features
+      adapter.get_all
+
+      expect(adapter.import(source_adapter)).to be(true)
+      expect(cache.read('flipper/v1/feature/changed')).to be_nil
+      expect(cache.read('flipper/v1/feature/added')).to be_nil
+      expect(cache.read('flipper/v1/feature/removed')).to be_nil
+      expect(cache.read('flipper/v1/features')).to be_nil
+      expect(cache.read('flipper/v1/get_all')).to be_nil
+      expect(flipper[:changed]).to be_enabled
+      expect(flipper[:added]).to be_enabled
+      expect(flipper[:removed]).not_to be_enabled
+    end
+
+    it 'preserves import errors without expiring caches' do
+      flipper[:existing].enable
+      adapter.get(flipper[:existing])
+      adapter.features
+      adapter.get_all
+
+      cached_feature = cache.read('flipper/v1/feature/existing')
+      cached_features = cache.read('flipper/v1/features')
+      cached_get_all = cache.read('flipper/v1/get_all')
+      error = Class.new(StandardError).new('import failed')
+      allow(memory_adapter).to receive(:import).and_raise(error)
+      expect(cache).not_to receive(:delete)
+
+      expect { adapter.import(Flipper::Adapters::Memory.new) }
+        .to raise_error { |raised| expect(raised).to be(error) }
+      expect(cache.read('flipper/v1/feature/existing')).to eq(cached_feature)
+      expect(cache.read('flipper/v1/features')).to eq(cached_features)
+      expect(cache.read('flipper/v1/get_all')).to eq(cached_get_all)
+    end
+
+    it 'does not expire caches when the wrapped adapter declines the import' do
+      flipper[:existing].enable
+      adapter.get(flipper[:existing])
+      allow(memory_adapter).to receive(:import).and_return(false)
+      expect(cache).not_to receive(:delete)
+
+      expect(adapter.import(Flipper::Adapters::Memory.new)).to be(false)
+      expect(cache.read('flipper/v1/feature/existing')).not_to be_nil
+    end
+  end
+
   describe '#name' do
     it 'is active_support_cache_store' do
       expect(subject.name).to be(:active_support_cache_store)


### PR DESCRIPTION
## Summary

- delegate cache-wrapper imports to the wrapped adapter so custom import behavior remains intact
- after a successful wrapped import, invalidate per-feature entries for the union of features before and after import, plus the feature-list and get-all entries
- preserve exceptions and false results without cache invalidation

The wrapped adapter import completes before cache invalidation begins; the cache is not part of the wrapped adapter's transaction. Ordinary cache-backed writes are unchanged. `Instrumented#import` already follows the same delegation contract and needs no change.

## Tests

- `bundle exec rspec -r active_support spec/flipper/adapters/active_support_cache_store_spec.rb` (99 examples, 0 failures)
- `bundle exec rspec spec/flipper/adapters/instrumented_spec.rb` (45 examples, 0 failures)
- `bundle exec rspec spec/flipper/adapters/redis_cache_spec.rb` (83 examples, 0 failures)
- `bundle exec ruby -Itest test/adapters/redis_cache_test.rb` (34 runs, 925 assertions, 0 failures)
- `bundle exec ruby -Itest test/adapters/dalli_test.rb` (34 runs, 925 assertions, 0 failures)
- `bundle exec rake test` (310 runs, 8,336 assertions, 0 failures)
- `bundle exec rspec -r active_support --exclude-pattern spec/flipper/cli_spec.rb` (3,074 examples, 0 failures; 162 pending service-specific ActiveRecord examples)

The unfiltered RSpec run reached 3,102 examples with only two unrelated existing CLI ANSI-color expectation failures in this local non-color environment.